### PR TITLE
Add option to output pull to stdout

### DIFF
--- a/cmd/cnab-to-oci/pull.go
+++ b/cmd/cnab-to-oci/pull.go
@@ -3,7 +3,9 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
+	"os"
 
 	"github.com/docker/cnab-to-oci/remotes"
 	"github.com/docker/distribution/reference"
@@ -45,6 +47,9 @@ func runPull(opts pullOptions) error {
 	if err != nil {
 		return err
 	}
-
+	if opts.output == "-" {
+		fmt.Fprintln(os.Stdout, string(bytes))
+		return nil
+	}
 	return ioutil.WriteFile(opts.output, bytes, 0644)
 }


### PR DESCRIPTION
Allows one to do:
```console
$ bin/cnab-to-oci pull ccrone/cnab@sha256:6cabd752cb01d2efb9485225baf7fc26f4322c1f45f537f76c5eeb67ba8d83e0 -o -
{
 "name": "helloworld",
 "version": "0.1.1",
 "description": "A short description of your bundle",
 "keywords": [
  "helloworld",
  "cnab",
  "tutorial"
 ],
 "maintainers": [
  {
   "name": "Jane Doe",
   "email": "jane.doe@example.com",
   "url": "https://example.com"
  }
 ],
 "invocationImages": [
  {
   "imageType": "docker",
   "image": "ccrone/cnab@sha256:a59a4e74d9cc89e4e75dfb2cc7ea5c108e4236ba6231b53081a9e2506d1197b6",
   "size": 942,
   "mediaType": "application/vnd.docker.distribution.manifest.v2+json"
  }
 ],
 "images": null,
 "parameters": null,
 "credentials": null
}
```