### PR TITLE
Per-registry PlainHTTP setting support instead of global

### DIFF
--- a/cmd/cnab-to-oci/pull.go
+++ b/cmd/cnab-to-oci/pull.go
@@ -13,9 +13,9 @@ import (
 )
 
 type pullOptions struct {
-	output    string
-	targetRef string
-	insecure  bool
+	output             string
+	targetRef          string
+	insecureRegistries []string
 }
 
 func pullCmd() *cobra.Command {
@@ -31,12 +31,12 @@ func pullCmd() *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&opts.output, "output", "o", "pulled.json", "output file")
-	cmd.Flags().BoolVar(&opts.insecure, "insecure", false, "Use insecure registry, without SSL")
+	cmd.Flags().StringSliceVar(&opts.insecureRegistries, "insecure-registries", nil, "Use plain HTTP for those registries")
 	return cmd
 }
 
 func runPull(opts pullOptions) error {
-	resolver := createResolver(opts.insecure)
+	resolver := createResolver(opts.insecureRegistries)
 	ref, err := reference.ParseNormalizedNamed(opts.targetRef)
 	if err != nil {
 		return err

--- a/cmd/cnab-to-oci/push.go
+++ b/cmd/cnab-to-oci/push.go
@@ -14,9 +14,9 @@ import (
 )
 
 type pushOptions struct {
-	input     string
-	targetRef string
-	insecure  bool
+	input              string
+	targetRef          string
+	insecureRegistries []string
 }
 
 func pushCmd() *cobra.Command {
@@ -35,7 +35,7 @@ func pushCmd() *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&opts.targetRef, "target", "t", "", "reference where the bundle will be pushed")
-	cmd.Flags().BoolVar(&opts.insecure, "insecure", false, "Use insecure registry, without SSL")
+	cmd.Flags().StringSliceVar(&opts.insecureRegistries, "insecure-registries", nil, "Use plain HTTP for those registries")
 	return cmd
 }
 
@@ -48,7 +48,7 @@ func runPush(opts pushOptions) error {
 	if err := json.Unmarshal(bundleJSON, &b); err != nil {
 		return err
 	}
-	resolver := createResolver(opts.insecure)
+	resolver := createResolver(opts.insecureRegistries)
 	ref, err := reference.ParseNormalizedNamed(opts.targetRef)
 	if err != nil {
 		return err

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -32,20 +32,20 @@ func TestPushAndPullCNAB(t *testing.T) {
 	// Save the fixed bundle
 	runCmd(t, icmd.Command("cnab-to-oci", "fixup", dir.Join("bundle.json"),
 		"--target", registry+"/myuser",
-		"--insecure",
+		"--insecure-registries", registry,
 		"--output", dir.Join("fixed-bundle.json")))
 
 	// Push the CNAB to the registry and get the digest
 	out := runCmd(t, icmd.Command("cnab-to-oci", "push", dir.Join("bundle.json"),
 		"--target", registry+"/myuser",
-		"--insecure"))
+		"--insecure-registries", registry))
 	re := regexp.MustCompile(`"(.*)"`)
 	digest := re.FindAllStringSubmatch(out, -1)[0][1]
 
 	// Pull the CNAB from the registry
 	runCmd(t, icmd.Command("cnab-to-oci", "pull", registry+"/myuser@"+digest,
 		"--output", dir.Join("pulled-bundle.json"),
-		"--insecure"))
+		"--insecure-registries", registry))
 	pulledBundle, err := ioutil.ReadFile(dir.Join("pulled-bundle.json"))
 	assert.NilError(t, err)
 

--- a/remotes/resolver.go
+++ b/remotes/resolver.go
@@ -1,27 +1,100 @@
 package remotes
 
 import (
+	"context"
+
+	"github.com/containerd/containerd/remotes"
 	"github.com/containerd/containerd/remotes/docker"
 	"github.com/docker/cli/cli/config/configfile"
+	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/registry"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
+type multiRegistryResolver struct {
+	plainHTTP           docker.ResolverBlobMounter
+	secure              docker.ResolverBlobMounter
+	plainHTTPRegistries map[string]struct{}
+}
+
+func (r *multiRegistryResolver) resolveImplementation(image string) (docker.ResolverBlobMounter, error) {
+	ref, err := reference.ParseNormalizedNamed(image)
+	if err != nil {
+		return nil, err
+	}
+	repoInfo, err := registry.ParseRepositoryInfo(ref)
+	if err != nil {
+		return nil, err
+	}
+	if _, plainHTTP := r.plainHTTPRegistries[repoInfo.Index.Name]; plainHTTP {
+		return r.plainHTTP, nil
+	}
+	return r.secure, nil
+}
+
+func (r *multiRegistryResolver) BlobMounter(ctx context.Context, ref string) (docker.BlobMounter, error) {
+	impl, err := r.resolveImplementation(ref)
+	if err != nil {
+		return nil, err
+	}
+	return impl.BlobMounter(ctx, ref)
+}
+
+func (r *multiRegistryResolver) Resolve(ctx context.Context, ref string) (name string, desc ocispec.Descriptor, err error) {
+	impl, err := r.resolveImplementation(ref)
+	if err != nil {
+		return "", ocispec.Descriptor{}, err
+	}
+	return impl.Resolve(ctx, ref)
+}
+
+func (r *multiRegistryResolver) Fetcher(ctx context.Context, ref string) (remotes.Fetcher, error) {
+	impl, err := r.resolveImplementation(ref)
+	if err != nil {
+		return nil, err
+	}
+	return impl.Fetcher(ctx, ref)
+}
+
+func (r *multiRegistryResolver) Pusher(ctx context.Context, ref string) (remotes.Pusher, error) {
+	impl, err := r.resolveImplementation(ref)
+	if err != nil {
+		return nil, err
+	}
+	return impl.Pusher(ctx, ref)
+}
+
 // CreateResolver creates a docker registry resolver, using the local docker CLI credentials
-func CreateResolver(cfg *configfile.ConfigFile, plainHTTP bool) docker.ResolverBlobMounter {
-	return docker.NewResolver(docker.ResolverOptions{
-		Authorizer: docker.NewAuthorizer(nil, func(hostName string) (string, string, error) {
-			if hostName == registry.DefaultV2Registry.Host {
-				hostName = registry.IndexServer
-			}
-			a, err := cfg.GetAuthConfig(hostName)
-			if err != nil {
-				return "", "", err
-			}
-			if a.IdentityToken != "" {
-				return "", a.IdentityToken, nil
-			}
-			return a.Username, a.Password, nil
-		}),
-		PlainHTTP: plainHTTP,
+func CreateResolver(cfg *configfile.ConfigFile, plainHTTPRegistries ...string) docker.ResolverBlobMounter {
+	authorizer := docker.NewAuthorizer(nil, func(hostName string) (string, string, error) {
+		if hostName == registry.DefaultV2Registry.Host {
+			hostName = registry.IndexServer
+		}
+		a, err := cfg.GetAuthConfig(hostName)
+		if err != nil {
+			return "", "", err
+		}
+		if a.IdentityToken != "" {
+			return "", a.IdentityToken, nil
+		}
+		return a.Username, a.Password, nil
 	})
+
+	result := &multiRegistryResolver{
+		plainHTTP: docker.NewResolver(docker.ResolverOptions{
+			Authorizer: authorizer,
+			PlainHTTP:  true,
+		}),
+		secure: docker.NewResolver(docker.ResolverOptions{
+			Authorizer: authorizer,
+			PlainHTTP:  false,
+		}),
+		plainHTTPRegistries: make(map[string]struct{}),
+	}
+
+	for _, r := range plainHTTPRegistries {
+		result.plainHTTPRegistries[r] = struct{}{}
+	}
+
+	return result
 }


### PR DESCRIPTION
When doing Fixups, we can have situations where only 1 of the source and target registries are insecure.
This brings the possibility to set the plainHTTP setting per-registry instead of globally.