### PR TITLE
Smarter fixup logic

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -35,6 +35,12 @@ func TestPushAndPullCNAB(t *testing.T) {
 		"--insecure-registries", registry,
 		"--output", dir.Join("fixed-bundle.json")))
 
+	// Re fix-up, checking it works twice
+	runCmd(t, icmd.Command("cnab-to-oci", "fixup", dir.Join("bundle.json"),
+		"--target", registry+"/myuser",
+		"--insecure-registries", registry,
+		"--output", dir.Join("fixed-bundle.json")))
+
 	// Push the CNAB to the registry and get the digest
 	out := runCmd(t, icmd.Command("cnab-to-oci", "push", dir.Join("bundle.json"),
 		"--target", registry+"/myuser",

--- a/remotes/fixup.go
+++ b/remotes/fixup.go
@@ -67,8 +67,12 @@ func fixupImage(ctx context.Context, baseImage bundle.BaseImage, ref reference.N
 	}
 
 	// Walk the source repository and list all the descriptors
-	accumulator := &descriptorAccumulator{}
-	if err := images.Walk(ctx, images.Handlers(accumulator, images.ChildrenHandler(&imageContentProvider{sourceFetcher})), descriptor); err != nil {
+	accumulator := &descriptorAccumulator{
+		childrenHandler: images.ChildrenHandler(&imageContentProvider{sourceFetcher}),
+		resolver:        resolver,
+		targetRepo:      repoOnly.String(),
+	}
+	if err := images.Walk(ctx, accumulator, descriptor); err != nil {
 		return bundle.BaseImage{}, err
 	}
 	for _, d := range accumulator.descriptors {


### PR DESCRIPTION
Before accumulating a descriptor and its children, we check if it is already present in the target repo.
This way, we can avoid pushing multiple time the same image, and we also can resume copies that have been interupted (skipping layers already copied)