### PR TITLE
Introduce an event sink and improve fixup

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -37,7 +37,7 @@
   revision = "3a771d992973f24aa725d07868b467d1ddfceafb"
 
 [[projects]]
-  digest = "1:6c6706e86f800e5c50f092454cefa168895fa0d1a488d0f2940db06a1c90d898"
+  digest = "1:98892dfa8897aaed7f4004a5c8fb28515dd3102d5b1fcd0c4987e31abc720f80"
   name = "github.com/containerd/containerd"
   packages = [
     "content",
@@ -51,7 +51,7 @@
     "version",
   ]
   pruneopts = "UT"
-  revision = "97d99161973592ddbf4b42a2073d61cc5bc46c57"
+  revision = "90dba5c4c05ca098b3de790d1f6f8ca1280ba921"
   source = "github.com/simonferquel/containerd"
 
 [[projects]]
@@ -376,9 +376,12 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:b521f10a2d8fa85c04a8ef4e62f2d1e14d303599a55d64dabf9f5a02f84d35eb"
+  digest = "1:d6b0cfc5ae30841c4b116ac589629f56f8add0955a39f11d8c0d06ca67f5b3d5"
   name = "golang.org/x/sync"
-  packages = ["errgroup"]
+  packages = [
+    "errgroup",
+    "semaphore",
+  ]
   pruneopts = "UT"
   revision = "42b317875d0fa942474b76e1b46a6060d720ae6e"
 
@@ -453,6 +456,7 @@
     "github.com/opencontainers/image-spec/specs-go/v1",
     "github.com/pkg/errors",
     "github.com/spf13/cobra",
+    "golang.org/x/sync/errgroup",
     "gotest.tools/assert",
     "gotest.tools/fs",
     "gotest.tools/golden",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -35,7 +35,7 @@
 [[constraint]]
   name = "github.com/containerd/containerd"
   source = "github.com/simonferquel/containerd"
-  revision = "97d99161973592ddbf4b42a2073d61cc5bc46c57"
+  revision = "90dba5c4c05ca098b3de790d1f6f8ca1280ba921"
 
 [[override]]
   name = "github.com/docker/cli"

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,7 @@ BUILD_ARGS := \
 
 GO_BUILD := CGO_ENABLED=0 go build -ldflags=$(LDFLAGS)
 GO_TEST := CGO_ENABLED=0 go test -ldflags=$(LDFLAGS) -failfast
+GO_TEST_RACE := go test -ldflags=$(LDFLAGS) -failfast -race
 
 all: build test
 
@@ -67,7 +68,7 @@ clean:
 test: test-unit test-e2e
 
 test-unit:
-	$(GO_TEST) $(shell go list ./... | grep -vE '/e2e')
+	$(GO_TEST_RACE) $(shell go list ./... | grep -vE '/e2e')
 
 test-e2e: e2e-image
 	docker run --rm --network=host -v /var/run/docker.sock:/var/run/docker.sock cnab-to-oci-e2e

--- a/cmd/cnab-to-oci/pull.go
+++ b/cmd/cnab-to-oci/pull.go
@@ -36,12 +36,11 @@ func pullCmd() *cobra.Command {
 }
 
 func runPull(opts pullOptions) error {
-	resolver := createResolver(opts.insecureRegistries)
 	ref, err := reference.ParseNormalizedNamed(opts.targetRef)
 	if err != nil {
 		return err
 	}
-	b, err := remotes.Pull(context.Background(), ref, resolver)
+	b, err := remotes.Pull(context.Background(), ref, createResolver(opts.insecureRegistries).Resolver)
 	if err != nil {
 		return err
 	}

--- a/cmd/cnab-to-oci/push.go
+++ b/cmd/cnab-to-oci/push.go
@@ -48,15 +48,17 @@ func runPush(opts pushOptions) error {
 	if err := json.Unmarshal(bundleJSON, &b); err != nil {
 		return err
 	}
-	resolver := createResolver(opts.insecureRegistries)
+	resolverConfig := createResolver(opts.insecureRegistries)
 	ref, err := reference.ParseNormalizedNamed(opts.targetRef)
 	if err != nil {
 		return err
 	}
-	if err := remotes.FixupBundle(context.Background(), &b, ref, resolver); err != nil {
+
+	err = remotes.FixupBundle(context.Background(), &b, ref, resolverConfig, remotes.WithEventCallback(displayEvent))
+	if err != nil {
 		return err
 	}
-	d, err := remotes.Push(context.Background(), &b, ref, resolver)
+	d, err := remotes.Push(context.Background(), &b, ref, resolverConfig.Resolver)
 	if err != nil {
 		return err
 	}

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -35,6 +35,12 @@ func TestPushAndPullCNAB(t *testing.T) {
 		"--insecure-registries", registry,
 		"--output", dir.Join("fixed-bundle.json")))
 
+	// Re fix-up, checking it works twice
+	runCmd(t, icmd.Command("cnab-to-oci", "fixup", dir.Join("bundle.json"),
+		"--target", registry+"/myuser",
+		"--insecure-registries", registry,
+		"--output", dir.Join("fixed-bundle.json")))
+
 	// Push the CNAB to the registry and get the digest
 	out := runCmd(t, icmd.Command("cnab-to-oci", "push", dir.Join("bundle.json"),
 		"--target", registry+"/myuser",

--- a/remotes/fixup.go
+++ b/remotes/fixup.go
@@ -2,29 +2,132 @@ package remotes
 
 import (
 	"context"
+	"errors"
 	"fmt"
-	"os"
+	"sync"
 
 	"github.com/containerd/containerd/images"
-	"github.com/containerd/containerd/remotes/docker"
+	"github.com/containerd/containerd/remotes"
 	"github.com/deislabs/duffle/pkg/bundle"
-	"github.com/docker/cli/opts"
+	"github.com/docker/cli/cli/config/configfile"
 	"github.com/docker/distribution/reference"
 	ocischemav1 "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
+const (
+	defaultMaxConcurrentJobs = 4
+	defaultJobsBufferLength  = 50
+)
+
+func noopEventCallback(FixupEvent) {}
+
+// fixupConfig defines the input required for a Fixup operation
+type fixupConfig struct {
+	bundle            *bundle.Bundle
+	targetRef         reference.Named
+	eventCallback     func(FixupEvent)
+	maxConcurrentJobs int
+	jobsBufferLength  int
+	resolverConfig    ResolverConfig
+}
+
+func (cfg *fixupConfig) complete() error {
+	if cfg.resolverConfig.Resolver == nil || cfg.resolverConfig.OriginProviderWrapper == nil {
+		return errors.New("resolver and originProviderWrapper are required, please use a complete ResolverConfig")
+	}
+	return nil
+}
+
+// WithEventCallback specifies a callback to execute for each Fixup event
+func WithEventCallback(callback func(FixupEvent)) FixupOption {
+	return func(cfg *fixupConfig) error {
+		cfg.eventCallback = callback
+		return nil
+	}
+}
+
+// WithParallelism provides a way to change the max concurrent jobs and the max number of jobs queued up
+func WithParallelism(maxConcurrentJobs int, jobsBufferLength int) FixupOption {
+	return func(cfg *fixupConfig) error {
+		cfg.maxConcurrentJobs = maxConcurrentJobs
+		cfg.jobsBufferLength = jobsBufferLength
+		return nil
+	}
+}
+
+// FixupOption is a helper for configuring a FixupBundle
+type FixupOption func(*fixupConfig) error
+
+// ResolverConfig represents a resolver and its associated OriginProviderWrapper
+type ResolverConfig struct {
+	Resolver              remotes.Resolver
+	OriginProviderWrapper OriginProviderWrapper
+}
+
+// NewResolverConfig creates a ResolverConfig
+func NewResolverConfig(resolver remotes.Resolver, originProviderWrapper OriginProviderWrapper) ResolverConfig {
+	return ResolverConfig{
+		Resolver:              resolver,
+		OriginProviderWrapper: originProviderWrapper,
+	}
+}
+
+// NewResolverConfigFromDockerConfigFile creates a ResolverConfig from a docker CLI config file and a list of registries to reach
+// using plain HTTP
+func NewResolverConfigFromDockerConfigFile(cfg *configfile.ConfigFile, plainHTTPRegistries ...string) ResolverConfig {
+	resolver, originProviderWrapper := CreateResolver(cfg, plainHTTPRegistries...)
+	return NewResolverConfig(resolver, originProviderWrapper)
+}
+
+func newFixupConfig(b *bundle.Bundle, ref reference.Named, resolverConfig ResolverConfig, options ...FixupOption) (fixupConfig, error) {
+	cfg := fixupConfig{
+		bundle:            b,
+		targetRef:         ref,
+		resolverConfig:    resolverConfig,
+		eventCallback:     noopEventCallback,
+		jobsBufferLength:  defaultJobsBufferLength,
+		maxConcurrentJobs: defaultMaxConcurrentJobs,
+	}
+	for _, opt := range options {
+		if err := opt(&cfg); err != nil {
+			return fixupConfig{}, err
+		}
+	}
+	if err := cfg.complete(); err != nil {
+		return fixupConfig{}, err
+	}
+	return cfg, nil
+}
+
 // FixupBundle checks that all the references are present in the referenced repository, otherwise it will mount all
 // the manifests to that repository. The bundle is then patched with the new digested references.
-func FixupBundle(ctx context.Context, b *bundle.Bundle, ref reference.Named, resolver docker.ResolverBlobMounter) error {
+func FixupBundle(ctx context.Context, b *bundle.Bundle, ref reference.Named, resolverConfig ResolverConfig, opts ...FixupOption) error {
+	cfg, err := newFixupConfig(b, ref, resolverConfig, opts...)
+	if err != nil {
+		return err
+	}
+	events := make(chan FixupEvent)
+	eventLoopDone := make(chan struct{})
+	defer func() {
+		close(events)
+		// wait for all queued events to be treated
+		<-eventLoopDone
+	}()
+	go func() {
+		defer close(eventLoopDone)
+		for ev := range events {
+			cfg.eventCallback(ev)
+		}
+	}()
+
 	if len(b.InvocationImages) != 1 {
 		return fmt.Errorf("only one invocation image supported for bundle %q", ref)
 	}
-	var err error
-	if b.InvocationImages[0].BaseImage, err = fixupImage(ctx, b.InvocationImages[0].BaseImage, ref, resolver); err != nil {
+	if b.InvocationImages[0].BaseImage, err = fixupImage(ctx, b.InvocationImages[0].BaseImage, cfg, events); err != nil {
 		return err
 	}
 	for name, original := range b.Images {
-		if original.BaseImage, err = fixupImage(ctx, original.BaseImage, ref, resolver); err != nil {
+		if original.BaseImage, err = fixupImage(ctx, original.BaseImage, cfg, events); err != nil {
 			return err
 		}
 		b.Images[name] = original
@@ -32,58 +135,70 @@ func FixupBundle(ctx context.Context, b *bundle.Bundle, ref reference.Named, res
 	return nil
 }
 
-func fixupImage(ctx context.Context, baseImage bundle.BaseImage, ref reference.Named, resolver docker.ResolverBlobMounter) (bundle.BaseImage, error) {
-	fmt.Fprintf(os.Stderr, "Ensuring image %s is present in repository %s\n", baseImage.Image, ref.Name())
-	repoOnly, imageRef, descriptor, err := fixupBaseImage(ctx, &baseImage, ref, resolver)
+func fixupImage(ctx context.Context, baseImage bundle.BaseImage, cfg fixupConfig, events chan<- FixupEvent) (_ bundle.BaseImage, retErr error) {
+	progress := &progress{}
+	originalSource := baseImage.Image
+	notifyEvent := func(eventType FixupEventType, message string, err error) {
+		events <- FixupEvent{
+			DestinationRef: cfg.targetRef,
+			SourceImage:    originalSource,
+			EventType:      eventType,
+			Message:        message,
+			Error:          err,
+			Progress:       progress.snapshot(),
+		}
+	}
+	defer func() {
+		if retErr != nil {
+			notifyEvent(FixupEventTypeCopyImageEnd, "", retErr)
+		}
+	}()
+	notifyEvent(FixupEventTypeCopyImageStart, "", nil)
+	repoOnly, imageRef, descriptor, err := fixupBaseImage(ctx, &baseImage, cfg.targetRef, cfg.resolverConfig.Resolver)
 	if err != nil {
 		return bundle.BaseImage{}, err
 	}
-	if imageRef.Name() == ref.Name() {
+	if imageRef.Name() == cfg.targetRef.Name() {
+		notifyEvent(FixupEventTypeCopyImageEnd, "Nothing to do: image reference is already present in repository"+repoOnly.String(), nil)
 		return baseImage, nil
 	}
-
-	fmt.Fprintln(os.Stderr, "Image is not present in repository")
 	sourceRepoOnly, err := reference.ParseNormalizedNamed(imageRef.Name())
 	if err != nil {
 		return bundle.BaseImage{}, err
 	}
-	sourceFetcher, err := resolver.Fetcher(ctx, sourceRepoOnly.Name())
+	sourceFetcher, err := cfg.resolverConfig.Resolver.Fetcher(ctx, sourceRepoOnly.Name())
 	if err != nil {
 		return bundle.BaseImage{}, err
 	}
+	if err := setFromImageReference(cfg.resolverConfig.OriginProviderWrapper, imageRef); err != nil {
+		return bundle.BaseImage{}, err
+	}
 
-	// Prepare the copier or the mounter
-	copier, err := newImageCopier(ctx, resolver, sourceFetcher, repoOnly.String())
+	// Prepare the copier
+	copier, err := newDescriptorCopier(ctx, cfg.resolverConfig.Resolver, sourceFetcher, repoOnly.String(), notifyEvent)
 	if err != nil {
 		return bundle.BaseImage{}, err
 	}
-	var handler imageHandler = &copier
-	if reference.Domain(imageRef) == reference.Domain(ref) {
-		mounter, err := newImageMounter(ctx, resolver, copier, sourceRepoOnly.Name(), repoOnly.Name())
-		if err != nil {
-			return bundle.BaseImage{}, err
-		}
-		handler = &mounter
+	descriptorContentHandler := &descriptorContentHandler{
+		descriptorCopier: copier,
+		targetRepo:       repoOnly.String(),
 	}
-
-	// Walk the source repository and list all the descriptors
-	accumulator := &descriptorAccumulator{}
-	if err := images.Walk(ctx, images.Handlers(accumulator, images.ChildrenHandler(&imageContentProvider{sourceFetcher})), descriptor); err != nil {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	scheduler := newErrgroupScheduler(ctx, cfg.maxConcurrentJobs, cfg.jobsBufferLength)
+	walker := newManifestWalker(notifyEvent, scheduler, progress, descriptorContentHandler)
+	walkerDep := walker.walk(scheduler.ctx(), descriptor, nil)
+	if err = walkerDep.wait(); err != nil {
 		return bundle.BaseImage{}, err
 	}
-	for _, d := range accumulator.descriptors {
-		if err := handler.Handle(ctx, d); err != nil {
-			return bundle.BaseImage{}, err
-		}
-	}
-
+	notifyEvent(FixupEventTypeCopyImageEnd, "", nil)
 	return baseImage, nil
 }
 
 func fixupBaseImage(ctx context.Context,
 	baseImage *bundle.BaseImage,
-	ref opts.NamedOption,
-	resolver docker.ResolverBlobMounter) (reference.Named, reference.Named, ocischemav1.Descriptor, error) {
+	ref reference.Named, //nolint: interfacer
+	resolver remotes.Resolver) (reference.Named, reference.Named, ocischemav1.Descriptor, error) {
 	err := checkBaseImage(baseImage)
 	if err != nil {
 		err := fmt.Errorf("invalid image %q: %s", ref, err)
@@ -135,4 +250,119 @@ func checkBaseImage(baseImage *bundle.BaseImage) error {
 	}
 
 	return nil
+}
+
+// FixupEvent is an event that is raised by the Fixup Logic
+type FixupEvent struct {
+	SourceImage    string
+	DestinationRef reference.Named
+	EventType      FixupEventType
+	Message        string
+	Error          error
+	Progress       ProgressSnapshot
+}
+
+// FixupEventType is the the type of event raised by the Fixup logic
+type FixupEventType string
+
+const (
+	// FixupEventTypeCopyImageStart is raised when the Fixup logic starts copying an
+	// image
+	FixupEventTypeCopyImageStart = FixupEventType("CopyImageStart")
+
+	// FixupEventTypeCopyImageEnd is raised when the Fixup logic stops copying an
+	// image. Error might be populated
+	FixupEventTypeCopyImageEnd = FixupEventType("CopyImageEnd")
+
+	// FixupEventTypeProgress is raised when Fixup logic reports progression
+	FixupEventTypeProgress = FixupEventType("Progress")
+)
+
+type descriptorProgress struct {
+	ocischemav1.Descriptor
+	done     bool
+	action   string
+	err      error
+	children []*descriptorProgress
+	mut      sync.RWMutex
+}
+
+func (p *descriptorProgress) markDone() {
+	p.mut.Lock()
+	defer p.mut.Unlock()
+	p.done = true
+}
+
+func (p *descriptorProgress) setAction(a string) {
+	p.mut.Lock()
+	defer p.mut.Unlock()
+	p.action = a
+}
+
+func (p *descriptorProgress) setError(err error) {
+	p.mut.Lock()
+	defer p.mut.Unlock()
+	p.err = err
+}
+
+func (p *descriptorProgress) addChild(child *descriptorProgress) {
+	p.mut.Lock()
+	defer p.mut.Unlock()
+	p.children = append(p.children, child)
+}
+
+func (p *descriptorProgress) snapshot() DescriptorProgressSnapshot {
+	p.mut.RLock()
+	defer p.mut.RUnlock()
+	result := DescriptorProgressSnapshot{
+		Descriptor: p.Descriptor,
+		Done:       p.done,
+		Action:     p.action,
+		Error:      p.err,
+	}
+	if len(p.children) != 0 {
+		result.Children = make([]DescriptorProgressSnapshot, len(p.children))
+		for ix, child := range p.children {
+			result.Children[ix] = child.snapshot()
+		}
+	}
+	return result
+}
+
+type progress struct {
+	roots []*descriptorProgress
+	mut   sync.RWMutex
+}
+
+func (p *progress) addRoot(root *descriptorProgress) {
+	p.mut.Lock()
+	defer p.mut.Unlock()
+	p.roots = append(p.roots, root)
+}
+
+func (p *progress) snapshot() ProgressSnapshot {
+	p.mut.RLock()
+	defer p.mut.RUnlock()
+	result := ProgressSnapshot{}
+	if len(p.roots) != 0 {
+		result.Roots = make([]DescriptorProgressSnapshot, len(p.roots))
+		for ix, root := range p.roots {
+			result.Roots[ix] = root.snapshot()
+		}
+	}
+	return result
+}
+
+// DescriptorProgressSnapshot describes the current progress of a descriptor
+type DescriptorProgressSnapshot struct {
+	ocischemav1.Descriptor
+	Done     bool
+	Action   string
+	Error    error
+	Children []DescriptorProgressSnapshot
+}
+
+// ProgressSnapshot describes the current progress of a Fixup operation
+type ProgressSnapshot struct {
+	Roots []DescriptorProgressSnapshot
 }

--- a/remotes/promises.go
+++ b/remotes/promises.go
@@ -1,0 +1,213 @@
+package remotes
+
+import (
+	"context"
+	"reflect"
+
+	"golang.org/x/sync/errgroup"
+)
+
+// scheduler is an abstraction over a component capable of running tasks
+// concurrently
+type scheduler interface {
+	// schedule a task and returns a promise notifying completion
+	schedule(func(ctx context.Context) error) promise
+	// ctx returns the context associated with this scheduler
+	ctx() context.Context
+}
+
+// dependency represents an asynchronous operation with its completion channel and its error state
+type dependency interface {
+	Done() <-chan struct{}
+	Err() error
+}
+
+// failedDependency is a dependency already ran to completion with an error
+type failedDependency struct {
+	err error
+}
+
+func (f failedDependency) Done() <-chan struct{} {
+	return doneCh
+}
+
+func (f failedDependency) Err() error {
+	return f.err
+}
+
+// doneDependency is a dependency already ran to completion without error
+type doneDependency struct {
+}
+
+func (doneDependency) Done() <-chan struct{} {
+	return doneCh
+}
+
+func (doneDependency) Err() error {
+	return nil
+}
+
+// doneCh is used internally by doneDependency and failedDependency (it is a closed channel)
+var doneCh = func() chan struct{} {
+	ch := make(chan struct{})
+	close(ch)
+	return ch
+}()
+
+// whenAll wrapps multiple dependencies in a single dependency
+// the result is completed once any dependency completes with an error
+// or once all dependencies ran to completion without error
+func whenAll(dependencies []dependency) dependency {
+	completionSource := &completionSource{
+		done: make(chan struct{}),
+	}
+	go func() {
+		defer close(completionSource.done)
+		cases := make([]reflect.SelectCase, len(dependencies))
+		for ix, dependency := range dependencies {
+			cases[ix] = reflect.SelectCase{
+				Chan: reflect.ValueOf(dependency.Done()),
+				Dir:  reflect.SelectRecv,
+			}
+		}
+		for len(dependencies) > 0 {
+			ix, _, _ := reflect.Select(cases)
+			if err := dependencies[ix].Err(); err != nil {
+				completionSource.err = err
+				return
+			}
+			cases = append(cases[:ix], cases[ix+1:]...)
+			dependencies = append(dependencies[:ix], dependencies[ix+1:]...)
+		}
+	}()
+	return completionSource
+}
+
+// promise is a dependency attached to a scheduler. It allows to schedule continuations
+type promise struct {
+	dependency
+	scheduler scheduler
+}
+
+func (p promise) wait() error {
+	<-p.Done()
+	return p.Err()
+}
+
+// then schedules a continuation task once the current promise is completed.
+// It propagates errors and returns a promise wrapping the continuation
+func (p promise) then(next func(ctx context.Context) error) promise {
+	completionSource := &completionSource{
+		done: make(chan struct{}),
+	}
+	go func() {
+		defer close(completionSource.done)
+		select {
+		case <-p.Done():
+			if err := p.Err(); err != nil {
+				completionSource.err = err
+				return
+			}
+			completionSource.err = p.scheduler.schedule(next).wait()
+		}
+	}()
+	return newPromise(p.scheduler, completionSource)
+}
+
+// newPromise creates a promise out of a dependency
+func newPromise(scheduler scheduler, dependency dependency) promise {
+	return promise{scheduler: scheduler, dependency: dependency}
+}
+
+// this schedule a task that itself produces a promise, and returns a promise wrapping the produced promise
+func scheduleAndUnwrap(scheduler scheduler, do func(ctx context.Context) (dependency, error)) promise {
+	completionSource := &completionSource{
+		done: make(chan struct{}),
+	}
+	scheduler.schedule(func(ctx context.Context) error {
+		p, err := do(ctx)
+		if err != nil {
+			completionSource.err = err
+			close(completionSource.done)
+			return err
+		}
+		go func() {
+			<-p.Done()
+			completionSource.err = p.Err()
+			close(completionSource.done)
+		}()
+		return nil
+	})
+	return newPromise(scheduler, completionSource)
+}
+
+// completion source is a a low-level dependency implementation used internally by the schedulers and promises
+type completionSource struct {
+	done chan struct{}
+	err  error
+}
+
+func (cs *completionSource) Done() <-chan struct{} {
+	return cs.done
+}
+
+func (cs *completionSource) Err() error {
+	return cs.err
+}
+
+// todoItem is an internal structure used by errgroupScheduler
+type todoItem struct {
+	completionSource *completionSource
+	do               func(ctx context.Context) error
+}
+
+// errgroupScheduler is a scheduler that cancels all tasks at the first error occurred
+type errgroupScheduler struct {
+	workGroup *errgroup.Group
+	todoList  chan todoItem
+	context   context.Context
+}
+
+func newErrgroupScheduler(ctx context.Context, workerCount, todoBuffer int) *errgroupScheduler {
+	todoList := make(chan todoItem, todoBuffer)
+	workGroup, ctx := errgroup.WithContext(ctx)
+	for i := 0; i < workerCount; i++ {
+		workGroup.Go(func() error {
+			for {
+				select {
+				case todoItem := <-todoList:
+					todoItem.completionSource.err = todoItem.do(ctx)
+					close(todoItem.completionSource.done)
+					if todoItem.completionSource.err != nil {
+						return todoItem.completionSource.err
+					}
+				case <-ctx.Done():
+					return ctx.Err()
+				}
+
+			}
+		})
+	}
+	return &errgroupScheduler{
+		todoList:  todoList,
+		workGroup: workGroup,
+		context:   ctx,
+	}
+}
+
+func (s *errgroupScheduler) schedule(do func(ctx context.Context) error) promise {
+	select {
+	case <-s.context.Done():
+		return newPromise(s, failedDependency{s.context.Err()})
+	default:
+	}
+	completionSource := &completionSource{
+		done: make(chan struct{}),
+	}
+	s.todoList <- todoItem{completionSource: completionSource, do: do}
+	return newPromise(s, completionSource)
+}
+
+func (s *errgroupScheduler) ctx() context.Context {
+	return s.context
+}

--- a/remotes/promises_test.go
+++ b/remotes/promises_test.go
@@ -1,0 +1,165 @@
+package remotes
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"gotest.tools/assert"
+)
+
+func TestPromisesNominal(t *testing.T) {
+	var mut sync.Mutex
+	var n int
+	var dependingValue int
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	scheduler := newErrgroupScheduler(ctx, 4, 5)
+	var deps []dependency
+	for i := 0; i < 4; i++ {
+		deps = append(deps, scheduler.schedule(func(ctx context.Context) error {
+			mut.Lock()
+			defer mut.Unlock()
+			n++
+			return nil
+		}))
+	}
+	final := newPromise(scheduler, whenAll(deps)).then(func(ctx context.Context) error {
+		dependingValue = n
+		return nil
+	})
+	assert.NilError(t, final.wait())
+	assert.Equal(t, n, 4)
+	assert.Equal(t, dependingValue, 4)
+}
+
+func TestPromisesCancelUnblock(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	scheduler := newErrgroupScheduler(ctx, 4, 5)
+	var done bool
+	started := make(chan struct{})
+	p := scheduler.schedule(func(ctx context.Context) error {
+		close(started)
+		<-ctx.Done()
+		done = true
+		return nil
+	})
+	<-started
+	cancel()
+	assert.NilError(t, p.wait())
+	assert.Check(t, done)
+}
+
+func TestPromisesErrorUnblock(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	scheduler := newErrgroupScheduler(ctx, 4, 5)
+	var done bool
+	p := scheduler.schedule(func(ctx context.Context) error {
+		<-ctx.Done()
+		done = true
+		return nil
+	})
+	erroring := scheduler.schedule(func(ctx context.Context) error {
+		return errors.New("boom")
+	})
+	assert.ErrorContains(t, erroring.wait(), "boom")
+	assert.NilError(t, p.wait())
+	assert.Check(t, done)
+}
+
+func TestPromisesScheduleErroredDontBlockDontRun(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	scheduler := newErrgroupScheduler(ctx, 4, 5)
+	errErroringTask := scheduler.schedule(func(ctx context.Context) error {
+		return errors.New("boom")
+	}).wait()
+	var done bool
+	errAfterError := scheduler.schedule(func(ctx context.Context) error {
+		done = true
+		return nil
+	}).wait()
+	assert.ErrorContains(t, errErroringTask, "boom")
+	assert.ErrorContains(t, errAfterError, "context canceled")
+	assert.Check(t, !done)
+}
+
+func TestPromisesErrorUnblockDeps(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	scheduler := newErrgroupScheduler(ctx, 4, 5)
+	dep := scheduler.schedule(func(ctx context.Context) error {
+		time.Sleep(200)
+		return errors.New("boom")
+	})
+	for i := 0; i < 50; i++ {
+		dep = dep.then(func(ctx context.Context) error {
+			return nil
+		})
+	}
+	assert.ErrorContains(t, dep.wait(), "boom")
+}
+
+func TestPromisesUnwrwap(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	scheduler := newErrgroupScheduler(ctx, 4, 5)
+	var done1, done2 bool
+	p := scheduleAndUnwrap(scheduler, func(ctx context.Context) (dependency, error) {
+		done1 = true
+		return scheduler.schedule(func(ctx context.Context) error {
+			time.Sleep(200)
+			done2 = true
+			return nil
+		}), nil
+	})
+	assert.NilError(t, p.wait())
+	assert.Check(t, done1)
+	assert.Check(t, done2)
+}
+
+func TestPromisesUnwrwapWithError(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	scheduler := newErrgroupScheduler(ctx, 4, 5)
+	var done bool
+	p := scheduleAndUnwrap(scheduler, func(ctx context.Context) (dependency, error) {
+		done = true
+		return nil, errors.New("boom")
+	})
+	assert.ErrorContains(t, p.wait(), "boom")
+	assert.Check(t, done)
+}
+
+func TestWhenAllWithErrorUnblocks(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	scheduler := newErrgroupScheduler(ctx, 4, 5)
+	var dependencies []dependency
+	// add a blocking task
+	dependencies = append(dependencies, scheduler.schedule(func(ctx context.Context) error {
+		<-ctx.Done()
+		return nil
+	}))
+	dependencies = append(dependencies, failedDependency{errors.New("boom")})
+	p := newPromise(scheduler, whenAll(dependencies)) // first error should be returned without waiting other
+	// tasks to complete
+	assert.ErrorContains(t, p.wait(), "boom")
+}
+
+func TestWhenAllWithErrorReported(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	scheduler := newErrgroupScheduler(ctx, 4, 5)
+	var dependencies []dependency
+	// add a blocking task
+	dependencies = append(dependencies, doneDependency{})
+	dependencies = append(dependencies, failedDependency{errors.New("boom")})
+	p := newPromise(scheduler, whenAll(dependencies)) // first error should be returned without waiting other
+	// tasks to complete
+	assert.ErrorContains(t, p.wait(), "boom")
+}

--- a/vendor/github.com/containerd/containerd/remotes/docker/auth.go
+++ b/vendor/github.com/containerd/containerd/remotes/docker/auth.go
@@ -79,8 +79,8 @@ func init() {
 		var t octetType
 		isCtl := c <= 31 || c == 127
 		isChar := 0 <= c && c <= 127
-		isSeparator := strings.IndexRune(" \t\"(),/:;<=>?@[]\\{}", rune(c)) >= 0
-		if strings.IndexRune(" \t\r\n", rune(c)) >= 0 {
+		isSeparator := strings.ContainsRune(" \t\"(),/:;<=>?@[]\\{}", rune(c))
+		if strings.ContainsRune(" \t\r\n", rune(c)) {
 			t |= isSpace
 		}
 		if isChar && !isCtl && !isSeparator {

--- a/vendor/github.com/containerd/containerd/remotes/docker/authorizer.go
+++ b/vendor/github.com/containerd/containerd/remotes/docker/authorizer.go
@@ -25,6 +25,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"strings"
 	"sync"
 	"time"
 
@@ -199,7 +200,11 @@ func (a *dockerAuthorizer) fetchTokenWithOAuth(ctx context.Context, to tokenOpti
 		form.Set("password", to.secret)
 	}
 
-	resp, err := ctxhttp.PostForm(ctx, a.client, to.realm, form)
+	resp, err := ctxhttp.Post(
+		ctx, a.client, to.realm,
+		"application/x-www-form-urlencoded; charset=utf-8",
+		strings.NewReader(form.Encode()),
+	)
 	if err != nil {
 		return "", err
 	}

--- a/vendor/github.com/containerd/containerd/remotes/docker/converter.go
+++ b/vendor/github.com/containerd/containerd/remotes/docker/converter.go
@@ -1,0 +1,88 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package docker
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/containerd/containerd/content"
+	"github.com/containerd/containerd/images"
+	"github.com/containerd/containerd/log"
+	"github.com/containerd/containerd/remotes"
+	digest "github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pkg/errors"
+)
+
+// LegacyConfigMediaType should be replaced by OCI image spec.
+//
+// More detail: docker/distribution#1622
+const LegacyConfigMediaType = "application/octet-stream"
+
+// ConvertManifest changes application/octet-stream to schema2 config media type if need.
+//
+// NOTE:
+// 1. original manifest will be deleted by next gc round.
+// 2. don't cover manifest list.
+func ConvertManifest(ctx context.Context, store content.Store, desc ocispec.Descriptor) (ocispec.Descriptor, error) {
+	if !(desc.MediaType == images.MediaTypeDockerSchema2Manifest ||
+		desc.MediaType == ocispec.MediaTypeImageManifest) {
+
+		log.G(ctx).Warnf("do nothing for media type: %s", desc.MediaType)
+		return desc, nil
+	}
+
+	// read manifest data
+	mb, err := content.ReadBlob(ctx, store, desc)
+	if err != nil {
+		return ocispec.Descriptor{}, errors.Wrap(err, "failed to read index data")
+	}
+
+	var manifest ocispec.Manifest
+	if err := json.Unmarshal(mb, &manifest); err != nil {
+		return ocispec.Descriptor{}, errors.Wrap(err, "failed to unmarshal data into manifest")
+	}
+
+	// check config media type
+	if manifest.Config.MediaType != LegacyConfigMediaType {
+		return desc, nil
+	}
+
+	manifest.Config.MediaType = images.MediaTypeDockerSchema2Config
+	data, err := json.MarshalIndent(manifest, "", "   ")
+	if err != nil {
+		return ocispec.Descriptor{}, errors.Wrap(err, "failed to marshal manifest")
+	}
+
+	// update manifest with gc labels
+	desc.Digest = digest.Canonical.FromBytes(data)
+	desc.Size = int64(len(data))
+
+	labels := map[string]string{}
+	for i, c := range append([]ocispec.Descriptor{manifest.Config}, manifest.Layers...) {
+		labels[fmt.Sprintf("containerd.io/gc.ref.content.%d", i)] = c.Digest.String()
+	}
+
+	ref := remotes.MakeRefKey(ctx, desc)
+	if err := content.WriteBlob(ctx, store, ref, bytes.NewReader(data), desc, content.WithLabels(labels)); err != nil {
+		return ocispec.Descriptor{}, errors.Wrap(err, "failed to update content")
+	}
+	return desc, nil
+}

--- a/vendor/github.com/containerd/containerd/remotes/docker/fetcher.go
+++ b/vendor/github.com/containerd/containerd/remotes/docker/fetcher.go
@@ -50,7 +50,7 @@ func (r dockerFetcher) Fetch(ctx context.Context, desc ocispec.Descriptor) (io.R
 		return nil, err
 	}
 
-	ctx, err = contextWithRepositoryScope(ctx, r.refspec, false)
+	ctx, err = contextWithRepositoryScope(ctx, r.refspec, false, false)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/golang.org/x/sync/semaphore/semaphore.go
+++ b/vendor/golang.org/x/sync/semaphore/semaphore.go
@@ -1,0 +1,127 @@
+// Copyright 2017 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package semaphore provides a weighted semaphore implementation.
+package semaphore // import "golang.org/x/sync/semaphore"
+
+import (
+	"container/list"
+	"context"
+	"sync"
+)
+
+type waiter struct {
+	n     int64
+	ready chan<- struct{} // Closed when semaphore acquired.
+}
+
+// NewWeighted creates a new weighted semaphore with the given
+// maximum combined weight for concurrent access.
+func NewWeighted(n int64) *Weighted {
+	w := &Weighted{size: n}
+	return w
+}
+
+// Weighted provides a way to bound concurrent access to a resource.
+// The callers can request access with a given weight.
+type Weighted struct {
+	size    int64
+	cur     int64
+	mu      sync.Mutex
+	waiters list.List
+}
+
+// Acquire acquires the semaphore with a weight of n, blocking only until ctx
+// is done. On success, returns nil. On failure, returns ctx.Err() and leaves
+// the semaphore unchanged.
+//
+// If ctx is already done, Acquire may still succeed without blocking.
+func (s *Weighted) Acquire(ctx context.Context, n int64) error {
+	s.mu.Lock()
+	if s.size-s.cur >= n && s.waiters.Len() == 0 {
+		s.cur += n
+		s.mu.Unlock()
+		return nil
+	}
+
+	if n > s.size {
+		// Don't make other Acquire calls block on one that's doomed to fail.
+		s.mu.Unlock()
+		<-ctx.Done()
+		return ctx.Err()
+	}
+
+	ready := make(chan struct{})
+	w := waiter{n: n, ready: ready}
+	elem := s.waiters.PushBack(w)
+	s.mu.Unlock()
+
+	select {
+	case <-ctx.Done():
+		err := ctx.Err()
+		s.mu.Lock()
+		select {
+		case <-ready:
+			// Acquired the semaphore after we were canceled.  Rather than trying to
+			// fix up the queue, just pretend we didn't notice the cancelation.
+			err = nil
+		default:
+			s.waiters.Remove(elem)
+		}
+		s.mu.Unlock()
+		return err
+
+	case <-ready:
+		return nil
+	}
+}
+
+// TryAcquire acquires the semaphore with a weight of n without blocking.
+// On success, returns true. On failure, returns false and leaves the semaphore unchanged.
+func (s *Weighted) TryAcquire(n int64) bool {
+	s.mu.Lock()
+	success := s.size-s.cur >= n && s.waiters.Len() == 0
+	if success {
+		s.cur += n
+	}
+	s.mu.Unlock()
+	return success
+}
+
+// Release releases the semaphore with a weight of n.
+func (s *Weighted) Release(n int64) {
+	s.mu.Lock()
+	s.cur -= n
+	if s.cur < 0 {
+		s.mu.Unlock()
+		panic("semaphore: bad release")
+	}
+	for {
+		next := s.waiters.Front()
+		if next == nil {
+			break // No more waiters blocked.
+		}
+
+		w := next.Value.(waiter)
+		if s.size-s.cur < w.n {
+			// Not enough tokens for the next waiter.  We could keep going (to try to
+			// find a waiter with a smaller request), but under load that could cause
+			// starvation for large requests; instead, we leave all remaining waiters
+			// blocked.
+			//
+			// Consider a semaphore used as a read-write lock, with N tokens, N
+			// readers, and one writer.  Each reader can Acquire(1) to obtain a read
+			// lock.  The writer can Acquire(N) to obtain a write lock, excluding all
+			// of the readers.  If we allow the readers to jump ahead in the queue,
+			// the writer will starve — there is always one token available for every
+			// reader.
+			break
+		}
+
+		s.cur += w.n
+		s.waiters.Remove(next)
+		close(w.ready)
+	}
+	s.mu.Unlock()
+}


### PR DESCRIPTION
This introduce an event sink instead of logging everything to os.Stderr.
The goal is for client code to control the rendering of events in a meaningfull way.

3 events are exposed:
- `CopyImageStart`: happens when the fixup logic starts working on an image
- `CopyImageEnd`: happens when the fixup logic ends working on an image (Error field is populated on error)
- `Progress`: a new progress snapshot has been recorded

The Client Code can choose the granularity of its display. The Progress snapshot exposes the whole graph of descriptor currently processed by the fixup logic.

Example of rich output that can be done:
![cnab-to-oci-out](https://user-images.githubusercontent.com/1677333/53430225-6326d600-39ee-11e9-947a-82bc68099dfc.gif)
