### PR TITLE
Fix write on closed channel error

### DIFF
--- a/remotes/fixup.go
+++ b/remotes/fixup.go
@@ -184,8 +184,11 @@ func fixupImage(ctx context.Context, baseImage bundle.BaseImage, cfg fixupConfig
 		targetRepo:       repoOnly.String(),
 	}
 	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
 	scheduler := newErrgroupScheduler(ctx, cfg.maxConcurrentJobs, cfg.jobsBufferLength)
+	defer func() {
+		cancel()
+		scheduler.drain()
+	}()
 	walker := newManifestWalker(notifyEvent, scheduler, progress, descriptorContentHandler)
 	walkerDep := walker.walk(scheduler.ctx(), descriptor, nil)
 	if err = walkerDep.wait(); err != nil {

--- a/remotes/promises.go
+++ b/remotes/promises.go
@@ -211,3 +211,8 @@ func (s *errgroupScheduler) schedule(do func(ctx context.Context) error) promise
 func (s *errgroupScheduler) ctx() context.Context {
 	return s.context
 }
+
+// nolint: unparam
+func (s *errgroupScheduler) drain() error {
+	return s.workGroup.Wait()
+}


### PR DESCRIPTION
In case of an error occuring in Fixup, there is a race condition where
we send an event after closing the event channel.

This is because the main task can complete (with an error) earlier than
other concurrent scheduled tasks running in the errgroup.

This adds a drain function to the errgroupScheduler to wait for all
goroutines to complete.
