### PR TITLE
Don't write a `nul` file on Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,20 +6,17 @@ PKG_NAME := github.com/docker/cnab-to-oci
 EXEC_EXT :=
 ifeq ($(OS),Windows_NT)
   EXEC_EXT := .exe
-  NULL := nul
-else
-  NULL := /dev/null
 endif
 
 ifeq ($(TAG),)
-  TAG := $(shell git describe --always --dirty 2> $(NULL))
+  TAG := $(shell git describe --always --dirty 2> /dev/null)
 endif
 ifeq ($(COMMIT),)
-  COMMIT := $(shell git rev-parse --short HEAD 2> $(NULL))
+  COMMIT := $(shell git rev-parse --short HEAD 2> /dev/null)
 endif
 
 ifeq ($(BUILDTIME),)
-  BUILDTIME := $(shell date -u +"%Y-%m-%dT%H:%M:%SZ" 2> $(NULL))
+  BUILDTIME := $(shell date -u +"%Y-%m-%dT%H:%M:%SZ" 2> /dev/null)
 endif
 ifeq ($(BUILDTIME),)
   BUILDTIME := unknown


### PR DESCRIPTION
The  2 > nul hack on Windows is only there for using within a cmd.exe
console. Current Makefile does only work within git bash (or wsl) on
Windows, and they make a "nul" file appear as bash does not handle this
redirection with anything special.

Worse, `nul` is actually a reserved name on Windows, and most APIs can't
manipulate a file named `nul` (and thus to remove it, you must either
run git bash or wsl).

As both WSL and git bash allow to redirect to /dev/null, this PR treats
Windows in the same way as Unix.

Signed-off-by: Simon Ferquel <simon.ferquel@docker.com>