### PR TITLE
Support single platform filter

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -84,12 +84,13 @@
   revision = "f95ca8e1ba6c22c9abcdbf65e8dcc39c53958bba"
 
 [[projects]]
-  digest = "1:a3fb9b04b18e11842fdcb83fe3cdadebeee5adeee321f1048d61593345439491"
+  digest = "1:af0babe595fd909d91ceb00ced5324f1fe964927dd12745db00ef1738771b853"
   name = "github.com/docker/distribution"
   packages = [
     ".",
     "digestset",
     "manifest",
+    "manifest/manifestlist",
     "manifest/schema2",
     "metrics",
     "reference",
@@ -436,6 +437,7 @@
     "github.com/containerd/containerd/content",
     "github.com/containerd/containerd/errdefs",
     "github.com/containerd/containerd/images",
+    "github.com/containerd/containerd/platforms",
     "github.com/containerd/containerd/reference",
     "github.com/containerd/containerd/remotes",
     "github.com/containerd/containerd/remotes/docker",
@@ -444,6 +446,7 @@
     "github.com/docker/cli/cli/config/configfile",
     "github.com/docker/cli/opts",
     "github.com/docker/distribution",
+    "github.com/docker/distribution/manifest/manifestlist",
     "github.com/docker/distribution/manifest/schema2",
     "github.com/docker/distribution/reference",
     "github.com/docker/distribution/registry/client/auth",

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -107,7 +107,7 @@
   revision = "83389a148052d74ac602f5f1d62f86ff2f3c4aa5"
 
 [[projects]]
-  digest = "1:f4ad803466fb70bc85d73f53aa3e7ac5809fed2282dc0bd682011433de557090"
+  digest = "1:f6e77103fc4af8cad88aa1b08b7e45dbf32a0b69ada2d598712ea09bf164119b"
   name = "github.com/docker/docker"
   packages = [
     "api/types",
@@ -413,7 +413,7 @@
   version = "v1.19.1"
 
 [[projects]]
-  digest = "1:9d7d5988129436e49ee34d17bf0229065f9c45e6fc85cad160464bd488dcacca"
+  digest = "1:9be45fef1734baa90b8201fa238b4c21a8d6478c278bf22cb7a76eb8abb6156f"
   name = "gotest.tools"
   packages = [
     "assert",

--- a/cmd/cnab-to-oci/push.go
+++ b/cmd/cnab-to-oci/push.go
@@ -61,7 +61,7 @@ func runPush(opts pushOptions) error {
 	}
 
 	err = remotes.FixupBundle(context.Background(), &b, ref, resolverConfig, remotes.WithEventCallback(displayEvent),
-		remotes.WithInovcationImagePlatforms(opts.invocationPlatforms),
+		remotes.WithInvocationImagePlatforms(opts.invocationPlatforms),
 		remotes.WithComponentImagePlatforms(opts.componentPlatforms))
 	if err != nil {
 		return err

--- a/cmd/cnab-to-oci/push.go
+++ b/cmd/cnab-to-oci/push.go
@@ -18,6 +18,7 @@ type pushOptions struct {
 	targetRef          string
 	insecureRegistries []string
 	allowFallbacks     bool
+	platform           string
 }
 
 func pushCmd() *cobra.Command {
@@ -38,6 +39,7 @@ func pushCmd() *cobra.Command {
 	cmd.Flags().StringVarP(&opts.targetRef, "target", "t", "", "reference where the bundle will be pushed")
 	cmd.Flags().StringSliceVar(&opts.insecureRegistries, "insecure-registries", nil, "Use plain HTTP for those registries")
 	cmd.Flags().BoolVar(&opts.allowFallbacks, "allow-fallbacks", true, "Enable automatic compatibility fallbacks for registries without support for custom media type, or OCI manifests")
+	cmd.Flags().StringVar(&opts.platform, "platform", "", "Single platform to push (instead of multi-arch images)")
 	return cmd
 }
 
@@ -56,7 +58,7 @@ func runPush(opts pushOptions) error {
 		return err
 	}
 
-	err = remotes.FixupBundle(context.Background(), &b, ref, resolverConfig, remotes.WithEventCallback(displayEvent))
+	err = remotes.FixupBundle(context.Background(), &b, ref, resolverConfig, remotes.WithEventCallback(displayEvent), remotes.WithSinglePlatform(opts.platform))
 	if err != nil {
 		return err
 	}

--- a/cmd/cnab-to-oci/push.go
+++ b/cmd/cnab-to-oci/push.go
@@ -14,11 +14,12 @@ import (
 )
 
 type pushOptions struct {
-	input              string
-	targetRef          string
-	insecureRegistries []string
-	allowFallbacks     bool
-	platform           string
+	input               string
+	targetRef           string
+	insecureRegistries  []string
+	allowFallbacks      bool
+	invocationPlatforms []string
+	componentPlatforms  []string
 }
 
 func pushCmd() *cobra.Command {
@@ -39,7 +40,8 @@ func pushCmd() *cobra.Command {
 	cmd.Flags().StringVarP(&opts.targetRef, "target", "t", "", "reference where the bundle will be pushed")
 	cmd.Flags().StringSliceVar(&opts.insecureRegistries, "insecure-registries", nil, "Use plain HTTP for those registries")
 	cmd.Flags().BoolVar(&opts.allowFallbacks, "allow-fallbacks", true, "Enable automatic compatibility fallbacks for registries without support for custom media type, or OCI manifests")
-	cmd.Flags().StringVar(&opts.platform, "platform", "", "Single platform to push (instead of multi-arch images)")
+	cmd.Flags().StringSliceVar(&opts.invocationPlatforms, "invocation-platforms", nil, "Platforms to push (for multi-arch invocation images)")
+	cmd.Flags().StringSliceVar(&opts.componentPlatforms, "component-platforms", nil, "Platforms to push (for multi-arch component images)")
 	return cmd
 }
 
@@ -58,7 +60,9 @@ func runPush(opts pushOptions) error {
 		return err
 	}
 
-	err = remotes.FixupBundle(context.Background(), &b, ref, resolverConfig, remotes.WithEventCallback(displayEvent), remotes.WithSinglePlatform(opts.platform))
+	err = remotes.FixupBundle(context.Background(), &b, ref, resolverConfig, remotes.WithEventCallback(displayEvent),
+		remotes.WithInovcationImagePlatforms(opts.invocationPlatforms),
+		remotes.WithComponentImagePlatforms(opts.componentPlatforms))
 	if err != nil {
 		return err
 	}

--- a/remotes/fixup.go
+++ b/remotes/fixup.go
@@ -46,8 +46,8 @@ func (cfg *fixupConfig) complete() error {
 	return nil
 }
 
-// WithInovcationImagePlatforms use filters platforms for an invocation image
-func WithInovcationImagePlatforms(supportedPlatforms []string) FixupOption {
+// WithInvocationImagePlatforms use filters platforms for an invocation image
+func WithInvocationImagePlatforms(supportedPlatforms []string) FixupOption {
 	return func(cfg *fixupConfig) error {
 		if len(supportedPlatforms) == 0 {
 			return nil
@@ -298,78 +298,6 @@ func fixupPlatforms(ctx context.Context, baseImage *bundle.BaseImage, fixupInfo 
 		return err
 	}
 	baseImage.Image = newRef.String()
-	return nil
-}
-
-type typelessManifestList struct {
-	Manifests []typelessDescriptor
-	extras    map[string]json.RawMessage
-}
-
-func (m *typelessManifestList) MarshalJSON() ([]byte, error) {
-	data := map[string]json.RawMessage{}
-	for k, v := range m.extras {
-		data[k] = v
-	}
-	if len(m.Manifests) != 0 {
-		manifestsJSON, err := json.Marshal(m.Manifests)
-		if err != nil {
-			return nil, err
-		}
-		data["manifests"] = json.RawMessage(manifestsJSON)
-	}
-	return json.Marshal(data)
-}
-
-func (m *typelessManifestList) UnmarshalJSON(source []byte) error {
-	var data map[string]json.RawMessage
-	if err := json.Unmarshal(source, &data); err != nil {
-		return err
-	}
-	if manifestsJSON, ok := data["manifests"]; ok {
-		if err := json.Unmarshal(manifestsJSON, &m.Manifests); err != nil {
-			return err
-		}
-		delete(data, "manifests")
-	}
-	m.extras = data
-	return nil
-}
-
-type typelessDescriptor struct {
-	Platform *ocischemav1.Platform
-	extras   map[string]json.RawMessage
-}
-
-func (d *typelessDescriptor) MarshalJSON() ([]byte, error) {
-	data := map[string]json.RawMessage{}
-	for k, v := range d.extras {
-		data[k] = v
-	}
-	if d.Platform != nil {
-		platJSON, err := json.Marshal(d.Platform)
-		if err != nil {
-			return nil, err
-		}
-		data["platform"] = json.RawMessage(platJSON)
-	}
-	return json.Marshal(data)
-}
-
-func (d *typelessDescriptor) UnmarshalJSON(source []byte) error {
-	var data map[string]json.RawMessage
-	if err := json.Unmarshal(source, &data); err != nil {
-		return err
-	}
-	if platJSON, ok := data["platform"]; ok {
-		var plat ocischemav1.Platform
-		if err := json.Unmarshal(platJSON, &plat); err != nil {
-			return err
-		}
-		d.Platform = &plat
-		delete(data, "platform")
-	}
-	d.extras = data
 	return nil
 }
 

--- a/remotes/fixup.go
+++ b/remotes/fixup.go
@@ -1,9 +1,13 @@
 package remotes
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"io/ioutil"
 	"sync"
 
 	"github.com/containerd/containerd/images"
@@ -12,6 +16,7 @@ import (
 	"github.com/deislabs/cnab-go/bundle"
 	"github.com/docker/cli/cli/config/configfile"
 	"github.com/docker/distribution/reference"
+	"github.com/opencontainers/go-digest"
 	ocischemav1 "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
@@ -24,13 +29,14 @@ func noopEventCallback(FixupEvent) {}
 
 // fixupConfig defines the input required for a Fixup operation
 type fixupConfig struct {
-	bundle            *bundle.Bundle
-	targetRef         reference.Named
-	eventCallback     func(FixupEvent)
-	maxConcurrentJobs int
-	jobsBufferLength  int
-	resolverConfig    ResolverConfig
-	platform          string
+	bundle                        *bundle.Bundle
+	targetRef                     reference.Named
+	eventCallback                 func(FixupEvent)
+	maxConcurrentJobs             int
+	jobsBufferLength              int
+	resolverConfig                ResolverConfig
+	invocationImagePlatformFilter []platforms.Matcher
+	componentImagePlatformFilter  []platforms.Matcher
 }
 
 func (cfg *fixupConfig) complete() error {
@@ -40,12 +46,40 @@ func (cfg *fixupConfig) complete() error {
 	return nil
 }
 
-// WithSinglePlatform use platform specif manifest instead of a manifestlist for multi-arch images
-func WithSinglePlatform(platform string) FixupOption {
+// WithInovcationImagePlatforms use filters platforms for an invocation image
+func WithInovcationImagePlatforms(supportedPlatforms []string) FixupOption {
 	return func(cfg *fixupConfig) error {
-		cfg.platform = platform
+		filter, err := toMatchers(supportedPlatforms)
+		if err != nil {
+			return err
+		}
+		cfg.invocationImagePlatformFilter = filter
 		return nil
 	}
+}
+
+// WithComponentImagePlatforms use filters platforms for an invocation image
+func WithComponentImagePlatforms(supportedPlatforms []string) FixupOption {
+	return func(cfg *fixupConfig) error {
+		filter, err := toMatchers(supportedPlatforms)
+		if err != nil {
+			return err
+		}
+		cfg.componentImagePlatformFilter = filter
+		return nil
+	}
+}
+
+func toMatchers(supportedPlatforms []string) ([]platforms.Matcher, error) {
+	result := make([]platforms.Matcher, len(supportedPlatforms))
+	for ix, p := range supportedPlatforms {
+		plat, err := platforms.Parse(p)
+		if err != nil {
+			return nil, err
+		}
+		result[ix] = platforms.NewMatcher(plat)
+	}
+	return result, nil
 }
 
 // WithEventCallback specifies a callback to execute for each Fixup event
@@ -133,11 +167,11 @@ func FixupBundle(ctx context.Context, b *bundle.Bundle, ref reference.Named, res
 	if len(b.InvocationImages) != 1 {
 		return fmt.Errorf("only one invocation image supported for bundle %q", ref)
 	}
-	if b.InvocationImages[0].BaseImage, err = fixupImage(ctx, b.InvocationImages[0].BaseImage, cfg, events); err != nil {
+	if b.InvocationImages[0].BaseImage, err = fixupImage(ctx, b.InvocationImages[0].BaseImage, cfg, events, cfg.invocationImagePlatformFilter); err != nil {
 		return err
 	}
 	for name, original := range b.Images {
-		if original.BaseImage, err = fixupImage(ctx, original.BaseImage, cfg, events); err != nil {
+		if original.BaseImage, err = fixupImage(ctx, original.BaseImage, cfg, events, cfg.componentImagePlatformFilter); err != nil {
 			return err
 		}
 		b.Images[name] = original
@@ -145,7 +179,7 @@ func FixupBundle(ctx context.Context, b *bundle.Bundle, ref reference.Named, res
 	return nil
 }
 
-func fixupImage(ctx context.Context, baseImage bundle.BaseImage, cfg fixupConfig, events chan<- FixupEvent) (_ bundle.BaseImage, retErr error) {
+func fixupImage(ctx context.Context, baseImage bundle.BaseImage, cfg fixupConfig, events chan<- FixupEvent, platformFilter []platforms.Matcher) (_ bundle.BaseImage, retErr error) {
 	progress := &progress{}
 	originalSource := baseImage.Image
 	notifyEvent := func(eventType FixupEventType, message string, err error) {
@@ -177,11 +211,12 @@ func fixupImage(ctx context.Context, baseImage bundle.BaseImage, cfg fixupConfig
 	if err != nil {
 		return bundle.BaseImage{}, err
 	}
-	sourceFetcher, err := cfg.resolverConfig.Resolver.Fetcher(ctx, sourceRepoOnly.Name())
+	f, err := cfg.resolverConfig.Resolver.Fetcher(ctx, sourceRepoOnly.Name())
 	if err != nil {
 		return bundle.BaseImage{}, err
 	}
-	if err := fixupPlatform(ctx, cfg, &baseImage, &fixupInfo, sourceFetcher); err != nil {
+	sourceFetcher := newSourceFetcherWithLocalData(f)
+	if err := fixupPlatforms(ctx, cfg, &baseImage, &fixupInfo, sourceFetcher, platformFilter); err != nil {
 		return bundle.BaseImage{}, err
 	}
 	if err := setFromImageReference(cfg.resolverConfig.OriginProviderWrapper, fixupInfo.sourceRef); err != nil {
@@ -212,21 +247,109 @@ func fixupImage(ctx context.Context, baseImage bundle.BaseImage, cfg fixupConfig
 	return baseImage, nil
 }
 
-// fixupPlatform resolve a single image manifest out of a manifest list if a platform filter has been specified
-// it modifies the baseImage and fixupInfo accordingly
-func fixupPlatform(ctx context.Context, cfg fixupConfig, baseImage *bundle.BaseImage, fixupInfo *imageFixupInfo, sourceFetcher remotes.Fetcher) error {
-	if cfg.platform == "" ||
+func fixupPlatforms(ctx context.Context, cfg fixupConfig, baseImage *bundle.BaseImage, fixupInfo *imageFixupInfo, sourceFetcher sourceFetcherAdder, filter []platforms.Matcher) error {
+	if len(filter) == 0 ||
 		(fixupInfo.resolvedDescriptor.MediaType != ocischemav1.MediaTypeImageIndex && fixupInfo.resolvedDescriptor.MediaType != images.MediaTypeDockerSchema2ManifestList) {
 		// no platform filter if platform is empty, or if the descriptor is not an OCI Index / Docker Manifest list
 		return nil
 	}
+	if len(filter) == 1 {
+		return fixupSinglePlatform(ctx, cfg, baseImage, fixupInfo, sourceFetcher, filter[0])
+	}
 
-	plat, err := platforms.Parse(cfg.platform)
+	reader, err := sourceFetcher.Fetch(ctx, fixupInfo.resolvedDescriptor)
 	if err != nil {
 		return err
 	}
-	matcher := platforms.NewMatcher(plat)
+	defer reader.Close()
 
+	manifestBytes, err := ioutil.ReadAll(reader)
+	if err != nil {
+		return err
+	}
+	var manifestList typelessManifestList
+	if err := json.Unmarshal(manifestBytes, &manifestList); err != nil {
+		return err
+	}
+	valid := 0
+	for _, d := range manifestList.Manifests {
+		if matchAny(d.Platform, filter) {
+			manifestList.Manifests[valid] = d
+			valid++
+		}
+	}
+	manifestList.Manifests = manifestList.Manifests[:valid]
+	manifestBytes, err = json.Marshal(&manifestList)
+	if err != nil {
+		return err
+	}
+	d := sourceFetcher.Add(manifestBytes)
+	descriptor := fixupInfo.resolvedDescriptor
+	descriptor.Digest = d
+	fixupInfo.resolvedDescriptor = descriptor
+	newRef, err := reference.WithDigest(fixupInfo.targetRepo, d)
+	if err != nil {
+		return err
+	}
+	baseImage.Image = newRef.String()
+	return nil
+}
+
+func matchAny(plat *ocischemav1.Platform, filter []platforms.Matcher) bool {
+	if plat == nil {
+		return false
+	}
+	for _, m := range filter {
+		if m.Match(*plat) {
+			return true
+		}
+	}
+	return false
+}
+
+type typelessManifestList struct {
+	Manifests []typelessDescriptor   `json:"manifests"`
+	Extras    map[string]interface{} `json:,inline`
+}
+
+type typelessDescriptor struct {
+	Platform *ocischemav1.Platform  `json:"platform,omitempty"`
+	Extras   map[string]interface{} `json:,inline`
+}
+
+type sourceFetcherAdder interface {
+	remotes.Fetcher
+	Add(data []byte) digest.Digest
+}
+
+type sourceFetcherWithLocalData struct {
+	inner     remotes.Fetcher
+	localData map[digest.Digest][]byte
+}
+
+func newSourceFetcherWithLocalData(inner remotes.Fetcher) *sourceFetcherWithLocalData {
+	return &sourceFetcherWithLocalData{
+		inner:     inner,
+		localData: make(map[digest.Digest][]byte),
+	}
+}
+
+func (s *sourceFetcherWithLocalData) Add(data []byte) digest.Digest {
+	d := digest.FromBytes(data)
+	s.localData[d] = data
+	return d
+}
+
+func (s *sourceFetcherWithLocalData) Fetch(ctx context.Context, desc ocischemav1.Descriptor) (io.ReadCloser, error) {
+	if v, ok := s.localData[desc.Digest]; ok {
+		return ioutil.NopCloser(bytes.NewReader(v)), nil
+	}
+	return s.inner.Fetch(ctx, desc)
+}
+
+// fixupSinglePlatform resolve a single image manifest out of a manifest list if a platform filter has been specified
+// it modifies the baseImage and fixupInfo accordingly
+func fixupSinglePlatform(ctx context.Context, cfg fixupConfig, baseImage *bundle.BaseImage, fixupInfo *imageFixupInfo, sourceFetcher remotes.Fetcher, matcher platforms.Matcher) error {
 	children, err := images.Children(ctx, &imageContentProvider{sourceFetcher}, fixupInfo.resolvedDescriptor)
 	if err != nil {
 		return err
@@ -242,7 +365,7 @@ func fixupPlatform(ctx context.Context, cfg fixupConfig, baseImage *bundle.BaseI
 			return nil
 		}
 	}
-	return fmt.Errorf("no image found for platform %q in %q", cfg.platform, fixupInfo.sourceRef)
+	return fmt.Errorf("no image found for platform %q in %q", matcher, fixupInfo.sourceRef)
 
 }
 

--- a/remotes/fixup_test.go
+++ b/remotes/fixup_test.go
@@ -1,0 +1,199 @@
+package remotes
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"io/ioutil"
+	"testing"
+
+	"github.com/containerd/containerd/images"
+	"github.com/containerd/containerd/remotes"
+	"github.com/deislabs/duffle/pkg/bundle"
+	"github.com/docker/distribution"
+	"github.com/docker/distribution/manifest/manifestlist"
+	"github.com/docker/distribution/reference"
+	"github.com/opencontainers/go-digest"
+	ocischema "github.com/opencontainers/image-spec/specs-go"
+	ocischemav1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"gotest.tools/assert"
+)
+
+func TestFixupPlatformShortPaths(t *testing.T) {
+	// those cases should not need to fetch any data
+	cases := []struct {
+		name      string
+		platform  string
+		mediaType string
+	}{
+		{
+			name:      "no-filter",
+			mediaType: ocischemav1.MediaTypeImageIndex,
+		},
+		{
+			name:      "oci-image",
+			platform:  "linux/amd64",
+			mediaType: ocischemav1.MediaTypeImageManifest,
+		},
+		{
+			name:      "docker-image",
+			platform:  "linux/amd64",
+			mediaType: images.MediaTypeDockerSchema2Manifest,
+		},
+		{
+			name:      "docker-image-schema1",
+			platform:  "linux/amd64",
+			mediaType: images.MediaTypeDockerSchema1Manifest,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			assert.NilError(t, fixupPlatform(context.Background(), fixupConfig{platform: c.platform}, nil, &imageFixupInfo{
+				resolvedDescriptor: ocischemav1.Descriptor{
+					MediaType: c.mediaType,
+				},
+			}, nil))
+		})
+	}
+}
+
+type fetchSetup struct {
+	descriptor ocischemav1.Descriptor
+	fetcher    remotes.Fetcher
+}
+
+type bytesFetcher []byte
+
+func (f bytesFetcher) Fetch(_ context.Context, _ ocischemav1.Descriptor) (io.ReadCloser, error) {
+	reader := bytes.NewReader(f)
+	return ioutil.NopCloser(reader), nil
+}
+
+func createFetchSetup(t *testing.T, ociFormat bool, descriptors ...ocischemav1.Descriptor) fetchSetup {
+	t.Helper()
+	var (
+		rootManifest []byte
+		mediaType    string
+	)
+	if ociFormat {
+		m := ocischemav1.Index{
+			Versioned: ocischema.Versioned{SchemaVersion: 2},
+			Manifests: descriptors,
+		}
+		bytes, err := json.Marshal(&m)
+		assert.NilError(t, err)
+		rootManifest = bytes
+		mediaType = ocischemav1.MediaTypeImageIndex
+	} else {
+		dockerDescriptors := make([]manifestlist.ManifestDescriptor, len(descriptors))
+		for ix, descriptor := range descriptors {
+			dockerDesc := manifestlist.ManifestDescriptor{
+				Descriptor: distribution.Descriptor{
+					MediaType: descriptor.MediaType,
+					Size:      descriptor.Size,
+					Digest:    descriptor.Digest,
+				},
+			}
+			if descriptor.Platform != nil {
+				dockerDesc.Platform = manifestlist.PlatformSpec{
+					Architecture: descriptor.Platform.Architecture,
+					OS:           descriptor.Platform.OS,
+				}
+			}
+			dockerDescriptors[ix] = dockerDesc
+		}
+		m, err := manifestlist.FromDescriptors(dockerDescriptors)
+		assert.NilError(t, err)
+		bytes, err := m.MarshalJSON()
+		assert.NilError(t, err)
+		rootManifest = bytes
+		mediaType = images.MediaTypeDockerSchema2ManifestList
+	}
+
+	rootDescriptor := ocischemav1.Descriptor{
+		Digest:    digest.FromBytes(rootManifest),
+		MediaType: mediaType,
+		Size:      int64(len(rootManifest)),
+	}
+	return fetchSetup{
+		descriptor: rootDescriptor,
+		fetcher:    bytesFetcher(rootManifest),
+	}
+}
+
+func TestFixupPlatformMultiArch(t *testing.T) {
+	linuxAmd64Descriptor := ocischemav1.Descriptor{
+		Digest:    digest.FromString("linux/amd64"),
+		MediaType: ocischemav1.MediaTypeImageManifest,
+		Platform: &ocischemav1.Platform{
+			Architecture: "amd64",
+			OS:           "linux",
+		},
+	}
+	linuxArm64Descriptor := ocischemav1.Descriptor{
+		Digest:    digest.FromString("linux/arm64"),
+		MediaType: ocischemav1.MediaTypeImageManifest,
+		Platform: &ocischemav1.Platform{
+			Architecture: "arm64",
+			OS:           "linux",
+		},
+	}
+	noPlatDescriptor := ocischemav1.Descriptor{
+		Digest:    digest.FromString("noplat"),
+		MediaType: ocischemav1.MediaTypeImageManifest,
+	}
+	cases := []struct {
+		name               string
+		platform           string
+		fetchSetup         fetchSetup
+		expectedDescriptor ocischemav1.Descriptor
+		expectedError      string
+	}{
+		{
+			name:               "match-ociindex",
+			platform:           "linux/amd64",
+			fetchSetup:         createFetchSetup(t, true, noPlatDescriptor, linuxArm64Descriptor, linuxAmd64Descriptor),
+			expectedDescriptor: linuxAmd64Descriptor,
+		},
+		{
+			name:               "match-manifestlist",
+			platform:           "linux/amd64",
+			fetchSetup:         createFetchSetup(t, false, noPlatDescriptor, linuxArm64Descriptor, linuxAmd64Descriptor),
+			expectedDescriptor: linuxAmd64Descriptor,
+		},
+		{
+			name:          "no-match-ociindex",
+			platform:      "windows/amd64",
+			fetchSetup:    createFetchSetup(t, true, noPlatDescriptor, linuxArm64Descriptor, linuxAmd64Descriptor),
+			expectedError: `no image found for platform "windows/amd64" in "docker.io/library/somerepo@sha256:51ae099fc17b7c56dc5e0b0a410cfa48928995776fa4b419cbfd4dca5605a85b"`,
+		},
+		{
+			name:          "no-match-manifestlist",
+			platform:      "windows/amd64",
+			fetchSetup:    createFetchSetup(t, false, noPlatDescriptor, linuxArm64Descriptor, linuxAmd64Descriptor),
+			expectedError: `no image found for platform "windows/amd64" in "docker.io/library/somerepo@sha256:8cc1363b2109e9c3e7b9b6e728669eb42eb25b09f8351d87236dda7cc26c6891"`,
+		},
+	}
+	targetRepo, err := reference.ParseNormalizedNamed("somerepo")
+	assert.NilError(t, err)
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			sourceRef, err := reference.WithDigest(targetRepo, c.fetchSetup.descriptor.Digest)
+			assert.NilError(t, err)
+			baseImage := &bundle.BaseImage{}
+			fixupInfo := &imageFixupInfo{resolvedDescriptor: c.fetchSetup.descriptor, targetRepo: targetRepo, sourceRef: sourceRef}
+			err = fixupPlatform(context.Background(), fixupConfig{platform: c.platform}, baseImage, fixupInfo, c.fetchSetup.fetcher)
+			if c.expectedError != "" {
+				assert.ErrorContains(t, err, c.expectedError)
+				return
+			}
+			assert.NilError(t, err)
+			assert.DeepEqual(t, fixupInfo.resolvedDescriptor, c.expectedDescriptor)
+			expectedImage, err := reference.WithDigest(targetRepo, c.expectedDescriptor.Digest)
+			assert.NilError(t, err)
+			assert.Equal(t, expectedImage.String(), baseImage.Image)
+		})
+	}
+}

--- a/remotes/fixup_test.go
+++ b/remotes/fixup_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/remotes"
-	"github.com/deislabs/duffle/pkg/bundle"
+	"github.com/deislabs/cnab-go/bundle"
 	"github.com/docker/distribution"
 	"github.com/docker/distribution/manifest/manifestlist"
 	"github.com/docker/distribution/reference"

--- a/remotes/typeless.go
+++ b/remotes/typeless.go
@@ -1,0 +1,79 @@
+package remotes
+
+import (
+	"encoding/json"
+
+	ocischemav1 "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+type typelessManifestList struct {
+	Manifests []typelessDescriptor
+	extras    map[string]json.RawMessage
+}
+
+func (m *typelessManifestList) MarshalJSON() ([]byte, error) {
+	data := map[string]json.RawMessage{}
+	for k, v := range m.extras {
+		data[k] = v
+	}
+	if len(m.Manifests) != 0 {
+		manifestsJSON, err := json.Marshal(m.Manifests)
+		if err != nil {
+			return nil, err
+		}
+		data["manifests"] = json.RawMessage(manifestsJSON)
+	}
+	return json.Marshal(data)
+}
+
+func (m *typelessManifestList) UnmarshalJSON(source []byte) error {
+	var data map[string]json.RawMessage
+	if err := json.Unmarshal(source, &data); err != nil {
+		return err
+	}
+	if manifestsJSON, ok := data["manifests"]; ok {
+		if err := json.Unmarshal(manifestsJSON, &m.Manifests); err != nil {
+			return err
+		}
+		delete(data, "manifests")
+	}
+	m.extras = data
+	return nil
+}
+
+type typelessDescriptor struct {
+	Platform *ocischemav1.Platform
+	extras   map[string]json.RawMessage
+}
+
+func (d *typelessDescriptor) MarshalJSON() ([]byte, error) {
+	data := map[string]json.RawMessage{}
+	for k, v := range d.extras {
+		data[k] = v
+	}
+	if d.Platform != nil {
+		platJSON, err := json.Marshal(d.Platform)
+		if err != nil {
+			return nil, err
+		}
+		data["platform"] = json.RawMessage(platJSON)
+	}
+	return json.Marshal(data)
+}
+
+func (d *typelessDescriptor) UnmarshalJSON(source []byte) error {
+	var data map[string]json.RawMessage
+	if err := json.Unmarshal(source, &data); err != nil {
+		return err
+	}
+	if platJSON, ok := data["platform"]; ok {
+		var plat ocischemav1.Platform
+		if err := json.Unmarshal(platJSON, &plat); err != nil {
+			return err
+		}
+		d.Platform = &plat
+		delete(data, "platform")
+	}
+	d.extras = data
+	return nil
+}

--- a/vendor/github.com/docker/distribution/manifest/manifestlist/manifestlist.go
+++ b/vendor/github.com/docker/distribution/manifest/manifestlist/manifestlist.go
@@ -1,0 +1,155 @@
+package manifestlist
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/docker/distribution"
+	"github.com/docker/distribution/manifest"
+	"github.com/opencontainers/go-digest"
+)
+
+// MediaTypeManifestList specifies the mediaType for manifest lists.
+const MediaTypeManifestList = "application/vnd.docker.distribution.manifest.list.v2+json"
+
+// SchemaVersion provides a pre-initialized version structure for this
+// packages version of the manifest.
+var SchemaVersion = manifest.Versioned{
+	SchemaVersion: 2,
+	MediaType:     MediaTypeManifestList,
+}
+
+func init() {
+	manifestListFunc := func(b []byte) (distribution.Manifest, distribution.Descriptor, error) {
+		m := new(DeserializedManifestList)
+		err := m.UnmarshalJSON(b)
+		if err != nil {
+			return nil, distribution.Descriptor{}, err
+		}
+
+		dgst := digest.FromBytes(b)
+		return m, distribution.Descriptor{Digest: dgst, Size: int64(len(b)), MediaType: MediaTypeManifestList}, err
+	}
+	err := distribution.RegisterManifestSchema(MediaTypeManifestList, manifestListFunc)
+	if err != nil {
+		panic(fmt.Sprintf("Unable to register manifest: %s", err))
+	}
+}
+
+// PlatformSpec specifies a platform where a particular image manifest is
+// applicable.
+type PlatformSpec struct {
+	// Architecture field specifies the CPU architecture, for example
+	// `amd64` or `ppc64`.
+	Architecture string `json:"architecture"`
+
+	// OS specifies the operating system, for example `linux` or `windows`.
+	OS string `json:"os"`
+
+	// OSVersion is an optional field specifying the operating system
+	// version, for example `10.0.10586`.
+	OSVersion string `json:"os.version,omitempty"`
+
+	// OSFeatures is an optional field specifying an array of strings,
+	// each listing a required OS feature (for example on Windows `win32k`).
+	OSFeatures []string `json:"os.features,omitempty"`
+
+	// Variant is an optional field specifying a variant of the CPU, for
+	// example `ppc64le` to specify a little-endian version of a PowerPC CPU.
+	Variant string `json:"variant,omitempty"`
+
+	// Features is an optional field specifying an array of strings, each
+	// listing a required CPU feature (for example `sse4` or `aes`).
+	Features []string `json:"features,omitempty"`
+}
+
+// A ManifestDescriptor references a platform-specific manifest.
+type ManifestDescriptor struct {
+	distribution.Descriptor
+
+	// Platform specifies which platform the manifest pointed to by the
+	// descriptor runs on.
+	Platform PlatformSpec `json:"platform"`
+}
+
+// ManifestList references manifests for various platforms.
+type ManifestList struct {
+	manifest.Versioned
+
+	// Config references the image configuration as a blob.
+	Manifests []ManifestDescriptor `json:"manifests"`
+}
+
+// References returns the distribution descriptors for the referenced image
+// manifests.
+func (m ManifestList) References() []distribution.Descriptor {
+	dependencies := make([]distribution.Descriptor, len(m.Manifests))
+	for i := range m.Manifests {
+		dependencies[i] = m.Manifests[i].Descriptor
+	}
+
+	return dependencies
+}
+
+// DeserializedManifestList wraps ManifestList with a copy of the original
+// JSON.
+type DeserializedManifestList struct {
+	ManifestList
+
+	// canonical is the canonical byte representation of the Manifest.
+	canonical []byte
+}
+
+// FromDescriptors takes a slice of descriptors, and returns a
+// DeserializedManifestList which contains the resulting manifest list
+// and its JSON representation.
+func FromDescriptors(descriptors []ManifestDescriptor) (*DeserializedManifestList, error) {
+	m := ManifestList{
+		Versioned: SchemaVersion,
+	}
+
+	m.Manifests = make([]ManifestDescriptor, len(descriptors), len(descriptors))
+	copy(m.Manifests, descriptors)
+
+	deserialized := DeserializedManifestList{
+		ManifestList: m,
+	}
+
+	var err error
+	deserialized.canonical, err = json.MarshalIndent(&m, "", "   ")
+	return &deserialized, err
+}
+
+// UnmarshalJSON populates a new ManifestList struct from JSON data.
+func (m *DeserializedManifestList) UnmarshalJSON(b []byte) error {
+	m.canonical = make([]byte, len(b), len(b))
+	// store manifest list in canonical
+	copy(m.canonical, b)
+
+	// Unmarshal canonical JSON into ManifestList object
+	var manifestList ManifestList
+	if err := json.Unmarshal(m.canonical, &manifestList); err != nil {
+		return err
+	}
+
+	m.ManifestList = manifestList
+
+	return nil
+}
+
+// MarshalJSON returns the contents of canonical. If canonical is empty,
+// marshals the inner contents.
+func (m *DeserializedManifestList) MarshalJSON() ([]byte, error) {
+	if len(m.canonical) > 0 {
+		return m.canonical, nil
+	}
+
+	return nil, errors.New("JSON representation not initialized in DeserializedManifestList")
+}
+
+// Payload returns the raw content of the manifest list. The contents can be
+// used to calculate the content identifier.
+func (m DeserializedManifestList) Payload() (string, []byte, error) {
+	return m.MediaType, m.canonical, nil
+}


### PR DESCRIPTION
When we want to push every image (inovcation-image + component images) with a single platform support, this collapse multi-arch image references into platform-specific image manifests.

This makes pushing the bundle much lighter when referencing official images supporting many flavor of os/arch combinations.