### PR TITLE
Mute containerd warnings on push

### DIFF
--- a/cmd/cnab-to-oci/push.go
+++ b/cmd/cnab-to-oci/push.go
@@ -7,9 +7,11 @@ import (
 	"fmt"
 	"io/ioutil"
 
+	"github.com/containerd/containerd/log"
 	"github.com/deislabs/cnab-go/bundle"
 	"github.com/docker/cnab-to-oci/remotes"
 	"github.com/docker/distribution/reference"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -66,7 +68,11 @@ func runPush(opts pushOptions) error {
 	if err != nil {
 		return err
 	}
-	d, err := remotes.Push(context.Background(), &b, ref, resolverConfig.Resolver, opts.allowFallbacks)
+	logger := logrus.New()
+	logger.SetLevel(logrus.FatalLevel)
+	logger.SetOutput(ioutil.Discard)
+	ctx := log.WithLogger(context.Background(), logrus.NewEntry(logger))
+	d, err := remotes.Push(ctx, &b, ref, resolverConfig.Resolver, opts.allowFallbacks)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
When pushing onto a registry accepting config media type
application/vnd.cnab.config.v1+json, containerd client lib emits a
warning: WARN[0015] reference for unknown type:
application/vnd.cnab.config.v1+json on stderr.

To avoid this, this PR set a muted logger to the push context

