### PR TITLE
Add helper --raw flag for pull to inspect raw manifest from registry

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -21,7 +21,7 @@ func TestPushAndPullCNAB(t *testing.T) {
 	registry := r.GetAddress(t)
 
 	// Create a CNAB bundle from a Docker Application Package
-	runCmd(t, icmd.Command("docker-app", "bundle", "/examples/hello-world/hello-world.dockerapp",
+	runCmd(t, icmd.Command("docker-app", "bundle", "/examples/hello-world/example-hello-world.dockerapp",
 		"--invocation-image", "hello-world:0.1.0-invoc",
 		"--namespace", registry+"/e2e",
 		"--out", dir.Join("bundle.json")))

--- a/remotes/pull.go
+++ b/remotes/pull.go
@@ -18,7 +18,7 @@ import (
 
 // Pull pulls a bundle from an OCI Image Index manifest
 func Pull(ctx context.Context, ref reference.Named, resolver remotes.Resolver) (*bundle.Bundle, error) {
-	index, err := getIndex(ctx, ref, resolver)
+	index, err := GetIndex(ctx, ref, resolver)
 	if err != nil {
 		return nil, err
 	}
@@ -29,7 +29,8 @@ func Pull(ctx context.Context, ref reference.Named, resolver remotes.Resolver) (
 	return converter.ConvertOCIIndexToBundle(&index, &config, ref)
 }
 
-func getIndex(ctx context.Context, ref auth.Scope, resolver remotes.Resolver) (ocischemav1.Index, error) {
+// GetIndex returns the OCI index
+func GetIndex(ctx context.Context, ref auth.Scope, resolver remotes.Resolver) (ocischemav1.Index, error) {
 	resolvedRef, indexDescriptor, err := resolver.Resolve(ctx, ref.String())
 	if err != nil {
 		return ocischemav1.Index{}, fmt.Errorf("failed to resolve bundle manifest %q: %s", ref, err)


### PR DESCRIPTION
closes #37 

This PR exposes `remotes.getIndex` (now `remotes.GetIndex`) so it can be used from outside the package, and adds a `--raw` flag for `cnab-to-oci pull` that writes the actual index to file instead of the converted bundle.