### PR TITLE
Fix image ordering

### DIFF
--- a/converter/convert.go
+++ b/converter/convert.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sort"
 
 	"github.com/containerd/containerd/images"
 	"github.com/deislabs/cnab-go/bundle"
@@ -177,7 +178,9 @@ func makeManifests(b *bundle.Bundle, targetReference reference.Named, bundleConf
 		CNABDescriptorTypeAnnotation: CNABDescriptorTypeInvocation,
 	}
 	manifests = append(manifests, invocationImage)
-	for name, img := range b.Images {
+	images := makeSortedImages(b.Images)
+	for _, name := range images {
+		img := b.Images[name]
 		image, err := makeDescriptor(img.BaseImage, targetReference)
 		if err != nil {
 			return nil, fmt.Errorf("invalid image: %s", err)
@@ -189,6 +192,15 @@ func makeManifests(b *bundle.Bundle, targetReference reference.Named, bundleConf
 		manifests = append(manifests, image)
 	}
 	return manifests, nil
+}
+
+func makeSortedImages(images map[string]bundle.Image) []string {
+	var result []string
+	for k := range images {
+		result = append(result, k)
+	}
+	sort.Strings(result)
+	return result
 }
 
 func parseManifests(descriptors []ocischemav1.Descriptor, into *bundle.Bundle, originRepo reference.Named) error {

--- a/remotes/push_test.go
+++ b/remotes/push_test.go
@@ -32,8 +32,8 @@ const (
           1
       ],
       "type": [
-          "string", 
-          "boolean", 
+          "string",
+          "boolean",
           "number"
       ]
     }
@@ -77,6 +77,15 @@ const (
       "size": 506,
       "annotations": {
         "io.cnab.manifest.type": "invocation"
+      }
+    },
+    {
+      "mediaType": "application/vnd.oci.image.manifest.v1+json",
+      "digest": "sha256:d59a1aa7866258751a261bae525a1842c7ff0662d4f34a355d5f36826abc0341",
+      "size": 507,
+      "annotations": {
+        "io.cnab.component.name": "another-image",
+        "io.cnab.manifest.type": "component"
       }
     },
     {
@@ -160,8 +169,8 @@ func ExamplePush() {
 	// Output:
 	// {
 	//   "mediaType": "application/vnd.oci.image.index.v1+json",
-	//   "digest": "sha256:afe79dfab78e26a121b860cec7dec5cf4ad5357e5c38dea32eab848a1f698491",
-	//   "size": 1170
+	//   "digest": "sha256:dc97d7daac08818c2361b30757d32e62b4326a85bcedcb22b8a5d45bf54d166d",
+	//   "size": 1416
 	// }
 }
 

--- a/tests/helpers.go
+++ b/tests/helpers.go
@@ -34,6 +34,14 @@ func MakeTestBundle() *bundle.Bundle {
 					Size:      507,
 				},
 			},
+			"another-image": {
+				BaseImage: bundle.BaseImage{
+					Image:     "my.registry/namespace/my-app@sha256:d59a1aa7866258751a261bae525a1842c7ff0662d4f34a355d5f36826abc0341",
+					ImageType: "oci",
+					MediaType: "application/vnd.oci.image.manifest.v1+json",
+					Size:      507,
+				},
+			},
 		},
 		InvocationImages: []bundle.InvocationImage{
 			{
@@ -111,6 +119,15 @@ func MakeTestOCIIndex() *ocischemav1.Index {
 				Size:      506,
 				Annotations: map[string]string{
 					"io.cnab.manifest.type": "invocation",
+				},
+			},
+			{
+				Digest:    "sha256:d59a1aa7866258751a261bae525a1842c7ff0662d4f34a355d5f36826abc0341",
+				MediaType: "application/vnd.oci.image.manifest.v1+json",
+				Size:      507,
+				Annotations: map[string]string{
+					"io.cnab.manifest.type":  "component",
+					"io.cnab.component.name": "another-image",
 				},
 			},
 			{


### PR DESCRIPTION
range over a map starts from a random index, making the final order of
images random, this will in turn generate different digests when pushing
the index. With this change the list of images will have a stable order,
resulting in a same digest for multiple pushes.