### PR TITLE
Fix bad manifest fallback configuration

### DIFF
--- a/converter/types.go
+++ b/converter/types.go
@@ -69,7 +69,7 @@ func (c *BundleConfig) PrepareForPush() (*PreparedBundleConfig, error) {
 		if current == nil {
 			first = cfg
 		} else {
-			first.Fallback = cfg
+			current.Fallback = cfg
 		}
 		current = cfg
 	}

--- a/converter/types_test.go
+++ b/converter/types_test.go
@@ -1,0 +1,27 @@
+package converter
+
+import (
+	"testing"
+
+	"gotest.tools/assert"
+)
+
+func TestPrepareForPush(t *testing.T) {
+	b := &BundleConfig{}
+	prepared, err := b.PrepareForPush()
+	assert.NilError(t, err)
+
+	// First try with OCI format and specific CNAB media type. Fallback should be set.
+	assert.Equal(t, prepared.ManifestDescriptor.MediaType, "application/vnd.oci.image.manifest.v1+json")
+	assert.Equal(t, prepared.ConfigBlobDescriptor.MediaType, "application/vnd.cnab.config.v1+json")
+	assert.Check(t, prepared.Fallback != nil)
+	// Try the first fallback, which set the media type to image config and still using OCI format
+	fallback := prepared.Fallback
+	assert.Equal(t, fallback.ManifestDescriptor.MediaType, "application/vnd.oci.image.manifest.v1+json")
+	assert.Equal(t, fallback.ConfigBlobDescriptor.MediaType, "application/vnd.oci.image.config.v1+json")
+	assert.Check(t, fallback.Fallback != nil)
+	// Last fallback uses Docker format
+	lastFallback := fallback.Fallback
+	assert.Equal(t, lastFallback.ManifestDescriptor.MediaType, "application/vnd.docker.distribution.manifest.v2+json")
+	assert.Equal(t, lastFallback.ConfigBlobDescriptor.MediaType, "application/vnd.docker.container.image.v1+json")
+}


### PR DESCRIPTION
While pushing the bundle configuration to a registry, we try first to use the OCI format with specific media type.
If it fails we try again with a more common media type, and if it fails we try a last time with Docker format.
All these fallbacks tries to reach maximum compatibility with all the deployed image registries.
But the fallback were not well configured, and the first one was missing. This is fixed now.

![image](https://user-images.githubusercontent.com/31478878/60898754-9bc2a000-a269-11e9-9122-c4f2ebc084b4.png)
