### PR TITLE
Bumped cnab-go dep

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -74,15 +74,15 @@
   revision = "004b46473808b3e7a4a3049c20e4376c91eb966d"
 
 [[projects]]
-  digest = "1:7f54abc3396e174a3bf19332e9be3af2992fe6efe08c4373348e65d41e3f2457"
+  digest = "1:9840201525a2e1ada0caf4089928e9d749cf8ec88bdb4ed8525211149610cc05"
   name = "github.com/deislabs/cnab-go"
   packages = [
     "bundle",
     "bundle/definition",
   ]
   pruneopts = "UT"
-  revision = "b8d6d13fdfc865b39cf29026ce169e6e709619dd"
-  version = "v0.1.2-beta1"
+  revision = "d0e47f49ea9a4ef8aedf1043b11ffa7506fc10d7"
+  version = "v0.2.0-beta1"
 
 [[projects]]
   digest = "1:982e3778851f5bb802c164c0baffa67eb7447b189211a08dd18acaa03b4d30c0"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -30,7 +30,7 @@
 
 [[constraint]]
   name = "github.com/deislabs/cnab-go"
-  version = "v0.1.2-beta.1"
+  version = "v0.2.0-beta.1"
 
 # Use master while we wait for https://github.com/containerd/containerd/pull/3218 to be included in the release
 [[constraint]]

--- a/vendor/github.com/deislabs/cnab-go/bundle/bundle.go
+++ b/vendor/github.com/deislabs/cnab-go/bundle/bundle.go
@@ -77,18 +77,12 @@ type LocationRef struct {
 
 // BaseImage contains fields shared across image types
 type BaseImage struct {
-	ImageType string         `json:"imageType" mapstructure:"imageType"`
-	Image     string         `json:"image" mapstructure:"image"`
-	Digest    string         `json:"digest,omitempty" mapstructure:"digest"`
-	Size      uint64         `json:"size,omitempty" mapstructure:"size"`
-	Platform  *ImagePlatform `json:"platform,omitempty" mapstructure:"platform"`
-	MediaType string         `json:"mediaType,omitempty" mapstructure:"mediaType"`
-}
-
-// ImagePlatform indicates what type of platform an image is built for
-type ImagePlatform struct {
-	Architecture string `json:"architecture,omitempty" mapstructure:"architecture"`
-	OS           string `json:"os,omitempty" mapstructure:"os"`
+	ImageType string            `json:"imageType" mapstructure:"imageType"`
+	Image     string            `json:"image" mapstructure:"image"`
+	Digest    string            `json:"digest,omitempty" mapstructure:"digest"`
+	Size      uint64            `json:"size,omitempty" mapstructure:"size"`
+	Labels    map[string]string `json:"labels,omitempty" mapstructure:"labels"`
+	MediaType string            `json:"mediaType,omitempty" mapstructure:"mediaType"`
 }
 
 // Image describes a container image in the bundle
@@ -101,6 +95,11 @@ type Image struct {
 type InvocationImage struct {
 	BaseImage `mapstructure:",squash"`
 }
+
+// Map that stores the relocated images
+// The key is the Image in bundle.json and the value is the new Image
+// from the relocated registry
+type ImageRelocationMap map[string]string
 
 // Location provides the location where a value should be written in
 // the invocation image.
@@ -133,13 +132,19 @@ type Action struct {
 	Description string `json:"description,omitempty" mapstructure:"description"`
 }
 
-// ValuesOrDefaults returns parameter values or the default parameter values
-func ValuesOrDefaults(vals map[string]interface{}, b *Bundle) (map[string]interface{}, error) {
+// ValuesOrDefaults returns parameter values or the default parameter values. An error is returned when the parameter value does not pass
+// the schema validation, a required parameter is missing or an immutable parameter is set with a new value.
+func ValuesOrDefaults(vals map[string]interface{}, currentVals map[string]interface{}, b *Bundle) (map[string]interface{}, error) {
+	res := map[string]interface{}{}
+
+	if b.Parameters == nil {
+		return res, nil
+	}
+
 	requiredMap := map[string]struct{}{}
 	for _, key := range b.Parameters.Required {
 		requiredMap[key] = struct{}{}
 	}
-	res := map[string]interface{}{}
 
 	for name, def := range b.Parameters.Fields {
 		s, ok := b.Definitions[def.Definition]
@@ -147,6 +152,9 @@ func ValuesOrDefaults(vals map[string]interface{}, b *Bundle) (map[string]interf
 			return res, fmt.Errorf("unable to find definition for %s", name)
 		}
 		if val, ok := vals[name]; ok {
+			if currentVal, ok := currentVals[name]; def.Immutable && ok && currentVal != val {
+				return res, fmt.Errorf("parameter %s is immutable and cannot be overridden with value %v", name, val)
+			}
 			valErrs, err := s.Validate(val)
 			if err != nil {
 				return res, pkgErrors.Wrapf(err, "encountered an error validating parameter %s", name)

--- a/vendor/github.com/deislabs/cnab-go/bundle/parameters.go
+++ b/vendor/github.com/deislabs/cnab-go/bundle/parameters.go
@@ -11,4 +11,5 @@ type ParameterDefinition struct {
 	ApplyTo     []string  `json:"applyTo,omitempty" mapstructure:"applyTo,omitempty"`
 	Description string    `json:"description,omitempty" mapstructure:"description"`
 	Destination *Location `json:"destination,omitemtpty" mapstructure:"destination"`
+	Immutable   bool      `json:"immutable,omitempty" mapstructure:"immutable,omitempty"`
 }


### PR DESCRIPTION
We just cut a release of cnab-go to v0.2.0-beta1 so I thought I'd send a PR to bump cnab-to-oci as well. 