### PR TITLE
Support bundle outputs

### DIFF
--- a/converter/convert.go
+++ b/converter/convert.go
@@ -87,6 +87,7 @@ func ConvertOCIIndexToBundle(ix *ocischemav1.Index, config *BundleConfig, origin
 		Credentials:   config.Credentials,
 		Definitions:   config.Definitions,
 		Parameters:    config.Parameters,
+		Outputs:       config.Outputs,
 		Custom:        config.Custom,
 	}
 	if err := parseTopLevelAnnotations(ix.Annotations, b); err != nil {

--- a/converter/types.go
+++ b/converter/types.go
@@ -24,6 +24,7 @@ type BundleConfig struct {
 	Actions       map[string]bundle.Action     `json:"actions,omitempty" mapstructure:"actions,omitempty"`
 	Definitions   definition.Definitions       `json:"definitions" mapstructure:"definitions"`
 	Parameters    map[string]bundle.Parameter  `json:"parameters" mapstructure:"parameters"`
+	Outputs       map[string]bundle.Output     `json:"outputs" mapstructure:"outputs"`
 	Credentials   map[string]bundle.Credential `json:"credentials" mapstructure:"credentials"`
 	Custom        map[string]interface{}       `json:"custom,omitempty" mapstructure:"custom"`
 }
@@ -44,6 +45,7 @@ func CreateBundleConfig(b *bundle.Bundle) *BundleConfig {
 		Actions:       b.Actions,
 		Definitions:   b.Definitions,
 		Parameters:    b.Parameters,
+		Outputs:       b.Outputs,
 		Credentials:   b.Credentials,
 		Custom:        b.Custom,
 	}

--- a/remotes/push_test.go
+++ b/remotes/push_test.go
@@ -24,6 +24,9 @@ const (
     }
   },
   "definitions": {
+    "output1Type": {
+      "type": "string"
+    },
     "param1Type": {
      "default": "hello",
       "enum": [
@@ -47,6 +50,16 @@ const (
       }
     }
   },
+  "outputs": {
+    "output1": {
+      "definition": "output1Type",
+      "applyTo": [
+        "install"
+      ],
+      "description": "magic",
+      "path": "/cnab/app/outputs/magic"
+    }
+  },
   "credentials": {
     "cred-1": {
       "path": "/some/path",
@@ -63,7 +76,7 @@ const (
   "manifests": [
     {
       "mediaType":"application/vnd.oci.image.manifest.v1+json",
-      "digest":"sha256:7867dc7fbfd606969a70686127d9c1a6c78a0b0b87fceea41452416e9d8146df",
+      "digest":"sha256:75b3dd7d430a5c5f20908dcb63099adedd555850735dbae833ab3312c6e42208",
       "size":188,
       "annotations":{
         "io.cnab.manifest.type":"config"
@@ -165,7 +178,7 @@ func ExamplePush() {
 	// Output:
 	// {
 	//   "mediaType": "application/vnd.oci.image.index.v1+json",
-	//   "digest": "sha256:7c1712e5dd027da28d3634a23a3e70ddf573b2f50ba2c211accdd929bb4c4782",
+	//   "digest": "sha256:ad9bf48bfc84342aae1017a486722b7b22c82a5f31bb2c4f6da81255e5aa09b5",
 	//   "size": 1363
 	// }
 }

--- a/tests/helpers.go
+++ b/tests/helpers.go
@@ -69,6 +69,9 @@ func MakeTestBundle() *bundle.Bundle {
 				Type:    []interface{}{"string", "boolean", "number"},
 				Default: "hello",
 			},
+			"output1Type": {
+				Type: "string",
+			},
 		},
 		Parameters: map[string]bundle.Parameter{
 			"param1": {
@@ -77,6 +80,14 @@ func MakeTestBundle() *bundle.Bundle {
 					EnvironmentVariable: "env_var",
 					Path:                "/some/path",
 				},
+			},
+		},
+		Outputs: map[string]bundle.Output{
+			"output1": {
+				Definition:  "output1Type",
+				Description: "magic",
+				ApplyTo:     []string{"install"},
+				Path:        "/cnab/app/outputs/magic",
 			},
 		},
 		Custom: map[string]interface{}{


### PR DESCRIPTION
This adds support for the bundle outputs field so that it's round tripped when a bundle with outputs defined is pushed/pulled to a registry.