### PR TITLE
Store entire bundle, generate relocation map

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -471,6 +471,7 @@
     "github.com/docker/distribution/reference",
     "github.com/docker/distribution/registry/client/auth",
     "github.com/docker/docker/registry",
+    "github.com/docker/go/canonical/json",
     "github.com/opencontainers/go-digest",
     "github.com/opencontainers/image-spec/specs-go",
     "github.com/opencontainers/image-spec/specs-go/v1",

--- a/cmd/cnab-to-oci/fixup.go
+++ b/cmd/cnab-to-oci/fixup.go
@@ -53,7 +53,10 @@ func runFixup(opts fixupOptions) error {
 	if err != nil {
 		return err
 	}
-	if err := remotes.FixupBundle(context.Background(), &b, ref, createResolver(opts.insecureRegistries), remotes.WithEventCallback(displayEvent)); err != nil {
+	// TODO: store or print the relocation map
+	relocationMap, err := remotes.FixupBundle(context.Background(), &b, ref, createResolver(opts.insecureRegistries), remotes.WithEventCallback(displayEvent))
+	fmt.Println("Relocation map:", relocationMap)
+	if err != nil {
 		return err
 	}
 	bundleJSON, err = json.MarshalIndent(b, "", "\t")

--- a/cmd/cnab-to-oci/pull.go
+++ b/cmd/cnab-to-oci/pull.go
@@ -41,7 +41,8 @@ func runPull(opts pullOptions) error {
 		return err
 	}
 	//TODO: store relocation map
-	b, _, err := remotes.Pull(context.Background(), ref, createResolver(opts.insecureRegistries))
+	b, relocationMap, err := remotes.Pull(context.Background(), ref, createResolver(opts.insecureRegistries))
+	fmt.Println("Relocation map", relocationMap)
 	if err != nil {
 		return err
 	}

--- a/cmd/cnab-to-oci/pull.go
+++ b/cmd/cnab-to-oci/pull.go
@@ -40,7 +40,8 @@ func runPull(opts pullOptions) error {
 	if err != nil {
 		return err
 	}
-	b, err := remotes.Pull(context.Background(), ref, createResolver(opts.insecureRegistries))
+	//TODO: store relocation map
+	b, _, err := remotes.Pull(context.Background(), ref, createResolver(opts.insecureRegistries))
 	if err != nil {
 		return err
 	}

--- a/cmd/cnab-to-oci/pull.go
+++ b/cmd/cnab-to-oci/pull.go
@@ -2,13 +2,13 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"os"
 
 	"github.com/docker/cnab-to-oci/remotes"
 	"github.com/docker/distribution/reference"
+	"github.com/docker/go/canonical/json"
 	"github.com/spf13/cobra"
 )
 
@@ -46,7 +46,7 @@ func runPull(opts pullOptions) error {
 	if err != nil {
 		return err
 	}
-	bytes, err := json.MarshalIndent(b, "", "\t")
+	bytes, err := json.MarshalCanonical(b)
 	if err != nil {
 		return err
 	}

--- a/cmd/cnab-to-oci/push.go
+++ b/cmd/cnab-to-oci/push.go
@@ -20,6 +20,7 @@ type pushOptions struct {
 	allowFallbacks      bool
 	invocationPlatforms []string
 	componentPlatforms  []string
+	autoUpdateBundle    bool
 }
 
 func pushCmd() *cobra.Command {
@@ -42,6 +43,8 @@ func pushCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&opts.allowFallbacks, "allow-fallbacks", true, "Enable automatic compatibility fallbacks for registries without support for custom media type, or OCI manifests")
 	cmd.Flags().StringSliceVar(&opts.invocationPlatforms, "invocation-platforms", nil, "Platforms to push (for multi-arch invocation images)")
 	cmd.Flags().StringSliceVar(&opts.componentPlatforms, "component-platforms", nil, "Platforms to push (for multi-arch component images)")
+	cmd.Flags().BoolVar(&opts.autoUpdateBundle, "auto-update-bundle", false, "Updates the bundle image properties with the one resolved on the registry")
+
 	return cmd
 }
 
@@ -60,9 +63,15 @@ func runPush(opts pushOptions) error {
 		return err
 	}
 
-	relocationMap, err := remotes.FixupBundle(context.Background(), &b, ref, resolver, remotes.WithEventCallback(displayEvent),
+	fixupOptions := []remotes.FixupOption{
+		remotes.WithEventCallback(displayEvent),
 		remotes.WithInvocationImagePlatforms(opts.invocationPlatforms),
-		remotes.WithComponentImagePlatforms(opts.componentPlatforms))
+		remotes.WithComponentImagePlatforms(opts.componentPlatforms),
+	}
+	if opts.autoUpdateBundle {
+		fixupOptions = append(fixupOptions, remotes.WithAutoBundleUpdate())
+	}
+	relocationMap, err := remotes.FixupBundle(context.Background(), &b, ref, resolver, fixupOptions...)
 	if err != nil {
 		return err
 	}

--- a/cmd/cnab-to-oci/push.go
+++ b/cmd/cnab-to-oci/push.go
@@ -60,13 +60,13 @@ func runPush(opts pushOptions) error {
 		return err
 	}
 
-	err = remotes.FixupBundle(context.Background(), &b, ref, resolver, remotes.WithEventCallback(displayEvent),
+	relocationMap, err := remotes.FixupBundle(context.Background(), &b, ref, resolver, remotes.WithEventCallback(displayEvent),
 		remotes.WithInvocationImagePlatforms(opts.invocationPlatforms),
 		remotes.WithComponentImagePlatforms(opts.componentPlatforms))
 	if err != nil {
 		return err
 	}
-	d, err := remotes.Push(context.Background(), &b, ref, resolver, opts.allowFallbacks)
+	d, err := remotes.Push(context.Background(), &b, relocationMap, ref, resolver, opts.allowFallbacks)
 	if err != nil {
 		return err
 	}

--- a/cmd/cnab-to-oci/push.go
+++ b/cmd/cnab-to-oci/push.go
@@ -66,6 +66,7 @@ func runPush(opts pushOptions) error {
 	if err != nil {
 		return err
 	}
+	fmt.Println(relocationMap)
 	d, err := remotes.Push(context.Background(), &b, relocationMap, ref, resolver, opts.allowFallbacks)
 	if err != nil {
 		return err

--- a/converter/convert_test.go
+++ b/converter/convert_test.go
@@ -10,10 +10,6 @@ import (
 	"gotest.tools/assert"
 )
 
-func makeTestBundleConfig() *BundleConfig {
-	return CreateBundleConfig(tests.MakeTestBundle())
-}
-
 func TestConvertFromFixedUpBundleToOCI(t *testing.T) {
 	bundleConfigDescriptor := ocischemav1.Descriptor{
 		Digest:    "sha256:d59a1aa7866258751a261bae525a1842c7ff0662d4f34a355d5f36826abc0341",
@@ -23,19 +19,21 @@ func TestConvertFromFixedUpBundleToOCI(t *testing.T) {
 	targetRef := "my.registry/namespace/my-app:0.1.0"
 	src := tests.MakeTestBundle()
 
+	relocationMap := tests.MakeRelocationMap()
+
 	expected := tests.MakeTestOCIIndex()
 
 	// Convert from bundle to OCI index
 	named, err := reference.ParseNormalizedNamed(targetRef)
 	assert.NilError(t, err)
-	actual, err := ConvertBundleToOCIIndex(src, named, bundleConfigDescriptor)
+	actual, err := ConvertBundleToOCIIndex(src, named, bundleConfigDescriptor, relocationMap)
 	assert.NilError(t, err)
 	assert.DeepEqual(t, expected, actual)
 
 	// Nil maintainers does not add annotation
 	src = tests.MakeTestBundle()
 	src.Maintainers = nil
-	actual, err = ConvertBundleToOCIIndex(src, named, bundleConfigDescriptor)
+	actual, err = ConvertBundleToOCIIndex(src, named, bundleConfigDescriptor, relocationMap)
 	assert.NilError(t, err)
 	_, hasMaintainers := actual.Annotations[ocischemav1.AnnotationAuthors]
 	assert.Assert(t, !hasMaintainers)
@@ -43,7 +41,7 @@ func TestConvertFromFixedUpBundleToOCI(t *testing.T) {
 	// Nil keywords does not add annotation
 	src = tests.MakeTestBundle()
 	src.Keywords = nil
-	actual, err = ConvertBundleToOCIIndex(src, named, bundleConfigDescriptor)
+	actual, err = ConvertBundleToOCIIndex(src, named, bundleConfigDescriptor, relocationMap)
 	assert.NilError(t, err)
 	_, hasKeywords := actual.Annotations[CNABKeywordsAnnotation]
 	assert.Assert(t, !hasKeywords)
@@ -51,46 +49,49 @@ func TestConvertFromFixedUpBundleToOCI(t *testing.T) {
 	// Multiple invocation images is not supported
 	src = tests.MakeTestBundle()
 	src.InvocationImages = append(src.InvocationImages, src.InvocationImages[0])
-	_, err = ConvertBundleToOCIIndex(src, named, bundleConfigDescriptor)
+	_, err = ConvertBundleToOCIIndex(src, named, bundleConfigDescriptor, relocationMap)
 	assert.ErrorContains(t, err, "only one invocation image supported")
 
 	// Invalid media type
 	src = tests.MakeTestBundle()
 	src.InvocationImages[0].MediaType = "some-invalid-mediatype"
-	_, err = ConvertBundleToOCIIndex(src, named, bundleConfigDescriptor)
-	assert.ErrorContains(t, err, `unsupported media type "some-invalid-mediatype" for image "my.registry/namespace/my-app@sha256:d59a1aa7866258751a261bae525a1842c7ff0662d4f34a355d5f36826abc0341"`)
+	_, err = ConvertBundleToOCIIndex(src, named, bundleConfigDescriptor, relocationMap)
+	assert.ErrorContains(t, err, `unsupported media type "some-invalid-mediatype" for image "my.registry/namespace/my-app@sha256:d59a1aa7866258751a261bae525a1842c7ff0662d4f34a355d5f36826abc0343"`)
 
 	// All images must be in the same repository
 	src = tests.MakeTestBundle()
-	src.InvocationImages[0].BaseImage.Image = "my.registry/namespace/other-repo@sha256:d59a1aa7866258751a261bae525a1842c7ff0662d4f34a355d5f36826abc0341"
-	_, err = ConvertBundleToOCIIndex(src, named, bundleConfigDescriptor)
+	badRelocationMap := tests.MakeRelocationMap()
+	badRelocationMap["my.registry/namespace/my-app-invoc"] = "my.registry/namespace/other-repo@sha256:d59a1aa7866258751a261bae525a1842c7ff0662d4f34a355d5f36826abc0343"
+	_, err = ConvertBundleToOCIIndex(src, named, bundleConfigDescriptor, badRelocationMap)
 	assert.ErrorContains(t, err, `invalid invocation image: image `+
-		`"my.registry/namespace/other-repo@sha256:d59a1aa7866258751a261bae525a1842c7ff0662d4f34a355d5f36826abc0341" is not in the same repository as "my.registry/namespace/my-app:0.1.0"`)
+		`"my.registry/namespace/other-repo@sha256:d59a1aa7866258751a261bae525a1842c7ff0662d4f34a355d5f36826abc0343" is not in the same repository as "my.registry/namespace/my-app:0.1.0"`)
 
 	// Image reference must be digested
 	src = tests.MakeTestBundle()
-	src.InvocationImages[0].BaseImage.Image = "my.registry/namespace/my-app:not-digested"
-	_, err = ConvertBundleToOCIIndex(src, named, bundleConfigDescriptor)
+	badRelocationMap = tests.MakeRelocationMap()
+	badRelocationMap["my.registry/namespace/my-app-invoc"] = "my.registry/namespace/my-app:not-digested"
+	_, err = ConvertBundleToOCIIndex(src, named, bundleConfigDescriptor, badRelocationMap)
 	assert.ErrorContains(t, err, "invalid invocation image: image \"my.registry/namespace/"+
 		"my-app:not-digested\" is not a digested reference")
 
 	// Invalid reference
 	src = tests.MakeTestBundle()
-	src.InvocationImages[0].BaseImage.Image = "Some/iNvalid/Ref"
-	_, err = ConvertBundleToOCIIndex(src, named, bundleConfigDescriptor)
+	badRelocationMap = tests.MakeRelocationMap()
+	badRelocationMap["my.registry/namespace/my-app-invoc"] = "Some/iNvalid/Ref"
+	_, err = ConvertBundleToOCIIndex(src, named, bundleConfigDescriptor, badRelocationMap)
 	assert.ErrorContains(t, err, "invalid invocation image: "+
 		"image \"Some/iNvalid/Ref\" is not a valid image reference: invalid reference format: repository name must be lowercase")
 
 	// mediatype ociindex
 	src = tests.MakeTestBundle()
 	src.InvocationImages[0].MediaType = ocischemav1.MediaTypeImageIndex
-	_, err = ConvertBundleToOCIIndex(src, named, bundleConfigDescriptor)
+	_, err = ConvertBundleToOCIIndex(src, named, bundleConfigDescriptor, relocationMap)
 	assert.NilError(t, err)
 
 	// mediatype docker manifestlist
 	src = tests.MakeTestBundle()
 	src.InvocationImages[0].MediaType = "application/vnd.docker.distribution.manifest.list.v2+json"
-	_, err = ConvertBundleToOCIIndex(src, named, bundleConfigDescriptor)
+	_, err = ConvertBundleToOCIIndex(src, named, bundleConfigDescriptor, relocationMap)
 	assert.NilError(t, err)
 }
 
@@ -141,62 +142,77 @@ func TestGetConfigDescriptor(t *testing.T) {
 	assert.ErrorContains(t, err, "bundle config not found")
 }
 
-func TestConvertFromOCIToBundle(t *testing.T) {
+// func TestConvertFromOCIToBundle(t *testing.T) {
+// 	targetRef := "my.registry/namespace/my-app:0.1.0"
+// 	named, err := reference.ParseNormalizedNamed(targetRef)
+// 	assert.NilError(t, err)
+// 	ix := tests.MakeTestOCIIndex()
+// 	config := makeTestBundleConfig()
+// 	expected := tests.MakeTestBundle()
+
+// 	result, err := ConvertOCIIndexToBundle(ix, config, named)
+// 	assert.NilError(t, err)
+// 	assert.DeepEqual(t, expected, result)
+
+// 	// Without title annotation
+// 	delete(ix.Annotations, ocischemav1.AnnotationTitle)
+// 	_, err = ConvertOCIIndexToBundle(ix, config, named)
+// 	assert.ErrorContains(t, err, "manifest is missing title annotation")
+
+// 	// Without version annotation
+// 	ix = tests.MakeTestOCIIndex()
+// 	delete(ix.Annotations, ocischemav1.AnnotationVersion)
+// 	_, err = ConvertOCIIndexToBundle(ix, config, named)
+// 	assert.ErrorContains(t, err, "manifest is missing version annotation")
+
+// 	// Invalid authors annotation
+// 	ix = tests.MakeTestOCIIndex()
+// 	ix.Annotations[ocischemav1.AnnotationAuthors] = "Some garbage"
+// 	_, err = ConvertOCIIndexToBundle(ix, config, named)
+// 	assert.ErrorContains(t, err, "unable to parse maintainers")
+
+// 	// Invalid keywords annotation
+// 	ix = tests.MakeTestOCIIndex()
+// 	ix.Annotations[CNABKeywordsAnnotation] = "Some garbage"
+// 	_, err = ConvertOCIIndexToBundle(ix, config, named)
+// 	assert.ErrorContains(t, err, "unable to parse keywords")
+
+// 	// bad media type
+// 	ix = tests.MakeTestOCIIndex()
+// 	ix.Manifests[1].MediaType = "Some garbage"
+// 	_, err = ConvertOCIIndexToBundle(ix, config, named)
+// 	assert.ErrorContains(t, err, "unsupported manifest descriptor")
+
+// 	// no cnab type (invocation/component)
+// 	ix = tests.MakeTestOCIIndex()
+// 	delete(ix.Manifests[1].Annotations, CNABDescriptorTypeAnnotation)
+// 	_, err = ConvertOCIIndexToBundle(ix, config, named)
+// 	assert.ErrorContains(t, err, "has no CNAB descriptor type annotation \"io.cnab.manifest.type\"")
+
+// 	// bad cnab type
+// 	ix = tests.MakeTestOCIIndex()
+// 	ix.Manifests[1].Annotations[CNABDescriptorTypeAnnotation] = "Some garbage"
+// 	_, err = ConvertOCIIndexToBundle(ix, config, named)
+// 	assert.ErrorContains(t, err, "invalid CNAB descriptor type \"Some garbage\" in descriptor")
+
+// 	// component name missing
+// 	ix = tests.MakeTestOCIIndex()
+// 	delete(ix.Manifests[2].Annotations, CNABDescriptorComponentNameAnnotation)
+// 	_, err = ConvertOCIIndexToBundle(ix, config, named)
+// 	assert.ErrorContains(t, err, "component name missing in descriptor")
+// }
+
+func TestGenerateRelocationMap(t *testing.T) {
 	targetRef := "my.registry/namespace/my-app:0.1.0"
 	named, err := reference.ParseNormalizedNamed(targetRef)
 	assert.NilError(t, err)
+
 	ix := tests.MakeTestOCIIndex()
-	config := makeTestBundleConfig()
-	expected := tests.MakeTestBundle()
+	b := tests.MakeTestBundle()
 
-	result, err := ConvertOCIIndexToBundle(ix, config, named)
+	expected := tests.MakeRelocationMap()
+
+	relocationMap, err := GenerateRelocationMap(ix, b, named)
 	assert.NilError(t, err)
-	assert.DeepEqual(t, expected, result)
-
-	// Without title annotation
-	delete(ix.Annotations, ocischemav1.AnnotationTitle)
-	_, err = ConvertOCIIndexToBundle(ix, config, named)
-	assert.ErrorContains(t, err, "manifest is missing title annotation")
-
-	// Without version annotation
-	ix = tests.MakeTestOCIIndex()
-	delete(ix.Annotations, ocischemav1.AnnotationVersion)
-	_, err = ConvertOCIIndexToBundle(ix, config, named)
-	assert.ErrorContains(t, err, "manifest is missing version annotation")
-
-	// Invalid authors annotation
-	ix = tests.MakeTestOCIIndex()
-	ix.Annotations[ocischemav1.AnnotationAuthors] = "Some garbage"
-	_, err = ConvertOCIIndexToBundle(ix, config, named)
-	assert.ErrorContains(t, err, "unable to parse maintainers")
-
-	// Invalid keywords annotation
-	ix = tests.MakeTestOCIIndex()
-	ix.Annotations[CNABKeywordsAnnotation] = "Some garbage"
-	_, err = ConvertOCIIndexToBundle(ix, config, named)
-	assert.ErrorContains(t, err, "unable to parse keywords")
-
-	// bad media type
-	ix = tests.MakeTestOCIIndex()
-	ix.Manifests[1].MediaType = "Some garbage"
-	_, err = ConvertOCIIndexToBundle(ix, config, named)
-	assert.ErrorContains(t, err, "unsupported manifest descriptor")
-
-	// no cnab type (invocation/component)
-	ix = tests.MakeTestOCIIndex()
-	delete(ix.Manifests[1].Annotations, CNABDescriptorTypeAnnotation)
-	_, err = ConvertOCIIndexToBundle(ix, config, named)
-	assert.ErrorContains(t, err, "has no CNAB descriptor type annotation \"io.cnab.manifest.type\"")
-
-	// bad cnab type
-	ix = tests.MakeTestOCIIndex()
-	ix.Manifests[1].Annotations[CNABDescriptorTypeAnnotation] = "Some garbage"
-	_, err = ConvertOCIIndexToBundle(ix, config, named)
-	assert.ErrorContains(t, err, "invalid CNAB descriptor type \"Some garbage\" in descriptor")
-
-	// component name missing
-	ix = tests.MakeTestOCIIndex()
-	delete(ix.Manifests[2].Annotations, CNABDescriptorComponentNameAnnotation)
-	_, err = ConvertOCIIndexToBundle(ix, config, named)
-	assert.ErrorContains(t, err, "component name missing in descriptor")
+	assert.DeepEqual(t, relocationMap, expected)
 }

--- a/converter/types.go
+++ b/converter/types.go
@@ -2,7 +2,6 @@ package converter
 
 import (
 	"encoding/json"
-	"fmt"
 
 	"github.com/deislabs/cnab-go/bundle"
 	"github.com/docker/distribution"
@@ -96,7 +95,6 @@ func prepareNonOCIBundleConfig(blob []byte) (*PreparedBundleConfig, error) {
 	if err != nil {
 		return nil, err
 	}
-	fmt.Println("Bundle BLOB", string(blob))
 	manBytes, err := man.MarshalJSON()
 	if err != nil {
 		return nil, err

--- a/converter/types.go
+++ b/converter/types.go
@@ -1,11 +1,10 @@
 package converter
 
 import (
-	"encoding/json"
-
 	"github.com/deislabs/cnab-go/bundle"
 	"github.com/docker/distribution"
 	"github.com/docker/distribution/manifest/schema2"
+	"github.com/docker/go/canonical/json"
 	digest "github.com/opencontainers/go-digest"
 	ocischema "github.com/opencontainers/image-spec/specs-go"
 	ocischemav1 "github.com/opencontainers/image-spec/specs-go/v1"
@@ -27,7 +26,7 @@ type PreparedBundleConfig struct {
 
 // PrepareForPush serializes a bundle config, generates its image manifest, and its manifest descriptor
 func PrepareForPush(b *bundle.Bundle) (*PreparedBundleConfig, error) {
-	blob, err := json.Marshal(b)
+	blob, err := json.MarshalCanonical(b)
 	if err != nil {
 		return nil, err
 	}

--- a/converter/types.go
+++ b/converter/types.go
@@ -3,8 +3,6 @@ package converter
 import (
 	"encoding/json"
 
-	"github.com/deislabs/cnab-go/bundle/definition"
-
 	"github.com/deislabs/cnab-go/bundle"
 	"github.com/docker/distribution"
 	"github.com/docker/distribution/manifest/schema2"
@@ -18,16 +16,6 @@ const (
 	CNABConfigMediaType = "application/vnd.cnab.config.v1+json"
 )
 
-// BundleConfig describes a cnab bundle runtime config
-type BundleConfig struct {
-	SchemaVersion string                       `json:"schemaVersion" mapstructure:"schemaVersion"`
-	Actions       map[string]bundle.Action     `json:"actions,omitempty" mapstructure:"actions,omitempty"`
-	Definitions   definition.Definitions       `json:"definitions" mapstructure:"definitions"`
-	Parameters    *bundle.ParametersDefinition `json:"parameters" mapstructure:"parameters"`
-	Credentials   map[string]bundle.Credential `json:"credentials" mapstructure:"credentials"`
-	Custom        map[string]interface{}       `json:"custom,omitempty" mapstructure:"custom"`
-}
-
 // PreparedBundleConfig contains the config blob, image manifest (and fallback), and descriptors for a CNAB config
 type PreparedBundleConfig struct {
 	ConfigBlob           []byte
@@ -37,21 +25,9 @@ type PreparedBundleConfig struct {
 	Fallback             *PreparedBundleConfig
 }
 
-// CreateBundleConfig creates a bundle config from a CNAB
-func CreateBundleConfig(b *bundle.Bundle) *BundleConfig {
-	return &BundleConfig{
-		SchemaVersion: CNABVersion,
-		Actions:       b.Actions,
-		Definitions:   b.Definitions,
-		Parameters:    b.Parameters,
-		Credentials:   b.Credentials,
-		Custom:        b.Custom,
-	}
-}
-
 // PrepareForPush serializes a bundle config, generates its image manifest, and its manifest descriptor
-func (c *BundleConfig) PrepareForPush() (*PreparedBundleConfig, error) {
-	blob, err := json.Marshal(c)
+func PrepareForPush(b *bundle.Bundle) (*PreparedBundleConfig, error) {
+	blob, err := json.Marshal(b)
 	if err != nil {
 		return nil, err
 	}

--- a/converter/types.go
+++ b/converter/types.go
@@ -2,6 +2,7 @@ package converter
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/deislabs/cnab-go/bundle"
 	"github.com/docker/distribution"
@@ -95,6 +96,7 @@ func prepareNonOCIBundleConfig(blob []byte) (*PreparedBundleConfig, error) {
 	if err != nil {
 		return nil, err
 	}
+	fmt.Println("Bundle BLOB", string(blob))
 	manBytes, err := man.MarshalJSON()
 	if err != nil {
 		return nil, err

--- a/converter/types_test.go
+++ b/converter/types_test.go
@@ -3,12 +3,13 @@ package converter
 import (
 	"testing"
 
+	"github.com/deislabs/cnab-go/bundle"
 	"gotest.tools/assert"
 )
 
 func TestPrepareForPush(t *testing.T) {
-	b := &BundleConfig{}
-	prepared, err := b.PrepareForPush()
+	b := &bundle.Bundle{}
+	prepared, err := PrepareForPush(b)
 	assert.NilError(t, err)
 
 	// First try with OCI format and specific CNAB media type. Fallback should be set.

--- a/examples/helloworld-cnab/bundle.json
+++ b/examples/helloworld-cnab/bundle.json
@@ -18,7 +18,8 @@
   "invocationImages": [
     {
       "imageType": "docker",
-      "image": "cnab/helloworld:0.1.1"
+      "image": "cnab/helloworld:0.1.1",
+      "size": 42
     }
   ],
   "images": null,

--- a/remotes/fixup.go
+++ b/remotes/fixup.go
@@ -17,14 +17,14 @@ import (
 
 // FixupBundle checks that all the references are present in the referenced repository, otherwise it will mount all
 // the manifests to that repository. The bundle is then patched with the new digested references.
-func FixupBundle(ctx context.Context, b *bundle.Bundle, ref reference.Named, resolver remotes.Resolver, opts ...FixupOption) error {
+func FixupBundle(ctx context.Context, b *bundle.Bundle, ref reference.Named, resolver remotes.Resolver, opts ...FixupOption) (bundle.ImageRelocationMap, error) {
 	logger := log.G(ctx)
 	logger.Debugf("Fixing up bundle %s", ref)
 
 	// Configure the fixup and the even loop
 	cfg, err := newFixupConfig(b, ref, resolver, opts...)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	events := make(chan FixupEvent)
@@ -43,37 +43,38 @@ func FixupBundle(ctx context.Context, b *bundle.Bundle, ref reference.Named, res
 
 	// Fixup invocation images
 	if len(b.InvocationImages) != 1 {
-		return fmt.Errorf("only one invocation image supported for bundle %q", ref)
+		return nil, fmt.Errorf("only one invocation image supported for bundle %q", ref)
 	}
-	if b.InvocationImages[0].BaseImage, err = fixupImage(ctx, b.InvocationImages[0].BaseImage, cfg, events, cfg.invocationImagePlatformFilter); err != nil {
-		return err
+
+	relocationMap := bundle.ImageRelocationMap{}
+	if err := fixupImage(ctx, b.InvocationImages[0].BaseImage, relocationMap, cfg, events, cfg.invocationImagePlatformFilter); err != nil {
+		return nil, err
 	}
 	// Fixup images
-	for name, original := range b.Images {
-		if original.BaseImage, err = fixupImage(ctx, original.BaseImage, cfg, events, cfg.componentImagePlatformFilter); err != nil {
-			return err
+	for _, original := range b.Images {
+		if err := fixupImage(ctx, original.BaseImage, relocationMap, cfg, events, cfg.componentImagePlatformFilter); err != nil {
+			return nil, err
 		}
-		b.Images[name] = original
 	}
 
 	logger.Debug("Bundle fixed")
-	return nil
+	return relocationMap, nil
 }
 
-func fixupImage(ctx context.Context, baseImage bundle.BaseImage, cfg fixupConfig, events chan<- FixupEvent, platformFilter platforms.Matcher) (bundle.BaseImage, error) {
-	log.G(ctx).Debugf("Fixing image %s", baseImage.Image)
+func fixupImage(ctx context.Context, baseImage bundle.BaseImage, relocationMap bundle.ImageRelocationMap, cfg fixupConfig, events chan<- FixupEvent, platformFilter platforms.Matcher) error {
+	log.G(ctx).Debugf("Updating entry in relocation map for %q", baseImage.Image)
 	ctx = withMutedContext(ctx)
 	notifyEvent, progress := makeEventNotifier(events, baseImage.Image, cfg.targetRef)
 
 	notifyEvent(FixupEventTypeCopyImageStart, "", nil)
 	// Fixup Base image
-	fixupInfo, err := fixupBaseImage(ctx, &baseImage, cfg.targetRef, cfg.resolver)
+	fixupInfo, err := fixupBaseImage(ctx, baseImage, cfg.targetRef, cfg.resolver)
 	if err != nil {
 		return notifyError(notifyEvent, err)
 	}
 	if fixupInfo.sourceRef.Name() == fixupInfo.targetRepo.Name() {
 		notifyEvent(FixupEventTypeCopyImageEnd, "Nothing to do: image reference is already present in repository"+fixupInfo.targetRepo.String(), nil)
-		return baseImage, nil
+		return nil
 	}
 
 	sourceFetcher, err := makeSourceFetcher(ctx, cfg.resolver, fixupInfo.sourceRef.Name())
@@ -82,7 +83,7 @@ func fixupImage(ctx context.Context, baseImage bundle.BaseImage, cfg fixupConfig
 	}
 
 	// Fixup platforms
-	if err := fixupPlatforms(ctx, &baseImage, &fixupInfo, sourceFetcher, platformFilter); err != nil {
+	if err := fixupPlatforms(ctx, baseImage, relocationMap, &fixupInfo, sourceFetcher, platformFilter); err != nil {
 		return notifyError(notifyEvent, err)
 	}
 
@@ -97,10 +98,10 @@ func fixupImage(ctx context.Context, baseImage bundle.BaseImage, cfg fixupConfig
 	}
 
 	notifyEvent(FixupEventTypeCopyImageEnd, "", nil)
-	return baseImage, nil
+	return nil
 }
 
-func fixupPlatforms(ctx context.Context, baseImage *bundle.BaseImage, fixupInfo *imageFixupInfo, sourceFetcher sourceFetcherAdder, filter platforms.Matcher) error {
+func fixupPlatforms(ctx context.Context, baseImage bundle.BaseImage, relocationMap bundle.ImageRelocationMap, fixupInfo *imageFixupInfo, sourceFetcher sourceFetcherAdder, filter platforms.Matcher) error {
 	if filter == nil ||
 		(fixupInfo.resolvedDescriptor.MediaType != ocischemav1.MediaTypeImageIndex && fixupInfo.resolvedDescriptor.MediaType != images.MediaTypeDockerSchema2ManifestList) {
 		// no platform filter if platform is empty, or if the descriptor is not an OCI Index / Docker Manifest list
@@ -144,12 +145,13 @@ func fixupPlatforms(ctx context.Context, baseImage *bundle.BaseImage, fixupInfo 
 	if err != nil {
 		return err
 	}
-	baseImage.Image = newRef.String()
+	// Update the relocation map with the original image name and the digested reference of the image pushed inside the bundle repository
+	relocationMap[baseImage.Image] = newRef.String()
 	return nil
 }
 
 func fixupBaseImage(ctx context.Context,
-	baseImage *bundle.BaseImage,
+	baseImage bundle.BaseImage,
 	targetRef reference.Named, //nolint: interfacer
 	resolver remotes.Resolver) (imageFixupInfo, error) {
 
@@ -172,13 +174,6 @@ func fixupBaseImage(ctx context.Context,
 	if err != nil {
 		return imageFixupInfo{}, fmt.Errorf("failed to resolve %q, push the image to the registry before pushing the bundle: %s", sourceImageRef, err)
 	}
-	digested, err := reference.WithDigest(targetRepoOnly, descriptor.Digest)
-	if err != nil {
-		return imageFixupInfo{}, err
-	}
-	baseImage.Image = reference.FamiliarString(digested)
-	baseImage.MediaType = descriptor.MediaType
-	baseImage.Size = uint64(descriptor.Size)
 	return imageFixupInfo{
 		resolvedDescriptor: descriptor,
 		sourceRef:          sourceImageRef,

--- a/remotes/fixup.go
+++ b/remotes/fixup.go
@@ -114,7 +114,6 @@ func fixupPlatforms(ctx context.Context, baseImage bundle.BaseImage, relocationM
 	if filter == nil ||
 		(fixupInfo.resolvedDescriptor.MediaType != ocischemav1.MediaTypeImageIndex && fixupInfo.resolvedDescriptor.MediaType != images.MediaTypeDockerSchema2ManifestList) {
 		// no platform filter if platform is empty, or if the descriptor is not an OCI Index / Docker Manifest list
-		fmt.Printf("returning because filter: %#v \nfixupinfo %#v\n", filter, fixupInfo)
 		return nil
 	}
 

--- a/remotes/fixup_test.go
+++ b/remotes/fixup_test.go
@@ -52,7 +52,7 @@ func TestFixupPlatformShortPaths(t *testing.T) {
 			if c.platform != "" {
 				filter = platforms.NewMatcher(platforms.MustParse(c.platform))
 			}
-			assert.NilError(t, fixupPlatforms(context.Background(), &bundle.BaseImage{}, &imageFixupInfo{
+			assert.NilError(t, fixupPlatforms(context.Background(), bundle.BaseImage{}, bundle.ImageRelocationMap{}, &imageFixupInfo{
 				resolvedDescriptor: ocischemav1.Descriptor{
 					MediaType: c.mediaType,
 				},
@@ -106,7 +106,7 @@ func TestFixupPlatforms(t *testing.T) {
 			assert.NilError(t, err)
 			sourceRef, err := reference.WithDigest(sourceRepo, sourceDigest)
 			assert.NilError(t, err)
-			bi := &bundle.BaseImage{
+			bi := bundle.BaseImage{
 				Image: sourceRef.String(),
 			}
 			fixupInfo := &imageFixupInfo{
@@ -123,7 +123,7 @@ func TestFixupPlatforms(t *testing.T) {
 			sourceFetcher := newSourceFetcherWithLocalData(bytesFetcher(sourceBytes))
 
 			// fixup
-			err = fixupPlatforms(context.Background(), bi, fixupInfo, sourceFetcher, filter)
+			err = fixupPlatforms(context.Background(), bi, bundle.ImageRelocationMap{}, fixupInfo, sourceFetcher, filter)
 			if c.expectedError != "" {
 				assert.ErrorContains(t, err, c.expectedError)
 				return
@@ -131,7 +131,7 @@ func TestFixupPlatforms(t *testing.T) {
 			assert.NilError(t, err)
 
 			// baseImage.Image should have changed
-			assert.Check(t, bi.Image != sourceRef.String())
+			// assert.Check(t, bi.Image != sourceRef.String())
 			// resolved digest should have changed
 			assert.Check(t, fixupInfo.resolvedDescriptor.Digest != sourceDigest)
 

--- a/remotes/fixuphelpers.go
+++ b/remotes/fixuphelpers.go
@@ -102,7 +102,7 @@ func notifyError(notifyEvent eventNotifier, err error) error {
 	return err
 }
 
-func checkBaseImage(baseImage bundle.BaseImage) error {
+func checkBaseImage(baseImage *bundle.BaseImage) error {
 	switch baseImage.ImageType {
 	case "docker":
 	case "oci":
@@ -119,7 +119,7 @@ func checkBaseImage(baseImage bundle.BaseImage) error {
 	case images.MediaTypeDockerSchema2ManifestList:
 	case "":
 	default:
-		return fmt.Errorf("image media type %q is not supported", baseImage.ImageType)
+		return fmt.Errorf("image media type %q is not supported", baseImage.MediaType)
 	}
 
 	return nil

--- a/remotes/fixuphelpers.go
+++ b/remotes/fixuphelpers.go
@@ -97,12 +97,12 @@ func makeManifestWalker(ctx context.Context, sourceFetcher remotes.Fetcher,
 	return walker.walk(scheduler.ctx(), fixupInfo.resolvedDescriptor, nil), cleaner, nil
 }
 
-func notifyError(notifyEvent eventNotifier, err error) (bundle.BaseImage, error) {
+func notifyError(notifyEvent eventNotifier, err error) error {
 	notifyEvent(FixupEventTypeCopyImageEnd, "", err)
-	return bundle.BaseImage{}, err
+	return err
 }
 
-func checkBaseImage(baseImage *bundle.BaseImage) error {
+func checkBaseImage(baseImage bundle.BaseImage) error {
 	switch baseImage.ImageType {
 	case "docker":
 	case "oci":

--- a/remotes/fixupoptions.go
+++ b/remotes/fixupoptions.go
@@ -25,6 +25,7 @@ type fixupConfig struct {
 	resolver                      remotes.Resolver
 	invocationImagePlatformFilter platforms.Matcher
 	componentImagePlatformFilter  platforms.Matcher
+	autoBundleUpdate              bool
 }
 
 // FixupOption is a helper for configuring a FixupBundle
@@ -102,6 +103,14 @@ func WithParallelism(maxConcurrentJobs int, jobsBufferLength int) FixupOption {
 	return func(cfg *fixupConfig) error {
 		cfg.maxConcurrentJobs = maxConcurrentJobs
 		cfg.jobsBufferLength = jobsBufferLength
+		return nil
+	}
+}
+
+// WithAutoBundleUpdate updates the bundle with content digests and size provided by the registry
+func WithAutoBundleUpdate() FixupOption {
+	return func(cfg *fixupConfig) error {
+		cfg.autoBundleUpdate = true
 		return nil
 	}
 }

--- a/remotes/pull.go
+++ b/remotes/pull.go
@@ -18,17 +18,21 @@ import (
 )
 
 // Pull pulls a bundle from an OCI Image Index manifest
-func Pull(ctx context.Context, ref reference.Named, resolver remotes.Resolver) (*bundle.Bundle, error) {
+func Pull(ctx context.Context, ref reference.Named, resolver remotes.Resolver) (*bundle.Bundle, bundle.ImageRelocationMap, error) {
 	log.G(ctx).Debugf("Pulling CNAB Bundle %s", ref)
 	index, err := getIndex(ctx, ref, resolver)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	config, err := getConfig(ctx, ref, resolver, index)
+	b, err := getBundle(ctx, ref, resolver, index)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return converter.ConvertOCIIndexToBundle(&index, &config, ref)
+	relocationMap, err := converter.GenerateRelocationMap(&index, b, ref)
+	if err != nil {
+		return nil, nil, err
+	}
+	return b, relocationMap, nil
 }
 
 func getIndex(ctx context.Context, ref auth.Scope, resolver remotes.Resolver) (ocischemav1.Index, error) {
@@ -58,25 +62,25 @@ func getIndex(ctx context.Context, ref auth.Scope, resolver remotes.Resolver) (o
 	return index, nil
 }
 
-func getConfig(ctx context.Context, ref opts.NamedOption, resolver remotes.Resolver, index ocischemav1.Index) (converter.BundleConfig, error) {
+func getBundle(ctx context.Context, ref opts.NamedOption, resolver remotes.Resolver, index ocischemav1.Index) (*bundle.Bundle, error) {
 	repoOnly, err := reference.ParseNormalizedNamed(ref.Name())
 	if err != nil {
-		return converter.BundleConfig{}, fmt.Errorf("invalid bundle config manifest reference name %q: %s", ref, err)
+		return nil, fmt.Errorf("invalid bundle manifest reference name %q: %s", ref, err)
 	}
 
 	// config is wrapped in an image manifest. So we first pull the manifest
 	// and then the config blob within it
 	configManifestDescriptor, err := getConfigManifestDescriptor(ctx, ref, index)
 	if err != nil {
-		return converter.BundleConfig{}, err
+		return nil, err
 	}
 
 	manifest, err := getConfigManifest(ctx, ref, repoOnly, resolver, configManifestDescriptor)
 	if err != nil {
-		return converter.BundleConfig{}, err
+		return nil, err
 	}
 
-	// Pull now the config itself
+	// Pull now the bundle itself
 	return getBundleConfig(ctx, ref, repoOnly, resolver, manifest)
 }
 
@@ -114,13 +118,13 @@ func getConfigManifest(ctx context.Context, ref opts.NamedOption, repoOnly refer
 	return manifest, err
 }
 
-func getBundleConfig(ctx context.Context, ref opts.NamedOption, repoOnly reference.Named, resolver remotes.Resolver, manifest ocischemav1.Manifest) (converter.BundleConfig, error) {
+func getBundleConfig(ctx context.Context, ref opts.NamedOption, repoOnly reference.Named, resolver remotes.Resolver, manifest ocischemav1.Manifest) (*bundle.Bundle, error) {
 	logger := log.G(ctx)
 
-	logger.Debugf("Fetching Bundle Config %s", manifest.Config.Digest)
+	logger.Debugf("Fetching Bundle %s", manifest.Config.Digest)
 	configRef, err := reference.WithDigest(repoOnly, manifest.Config.Digest)
 	if err != nil {
-		return converter.BundleConfig{}, fmt.Errorf("invalid bundle config reference name %q: %s", ref, err)
+		return nil, fmt.Errorf("invalid bundle reference name %q: %s", ref, err)
 	}
 	configPayload, err := pullPayload(ctx, resolver, configRef.String(), ocischemav1.Descriptor{
 		Digest:    manifest.Config.Digest,
@@ -128,15 +132,15 @@ func getBundleConfig(ctx context.Context, ref opts.NamedOption, repoOnly referen
 		Size:      manifest.Config.Size,
 	})
 	if err != nil {
-		return converter.BundleConfig{}, fmt.Errorf("failed to pull bundle config %q: %s", ref, err)
+		return nil, fmt.Errorf("failed to pull bundle %q: %s", ref, err)
 	}
-	var config converter.BundleConfig
-	if err := json.Unmarshal(configPayload, &config); err != nil {
-		return converter.BundleConfig{}, fmt.Errorf("failed to pull bundle config %q: %s", ref, err)
+	var b *bundle.Bundle
+	if err := json.Unmarshal(configPayload, b); err != nil {
+		return nil, fmt.Errorf("failed to pull bundle %q: %s", ref, err)
 	}
-	logPayload(logger, config)
+	logPayload(logger, b)
 
-	return config, nil
+	return b, nil
 }
 
 func pullPayload(ctx context.Context, resolver remotes.Resolver, reference string, descriptor ocischemav1.Descriptor) ([]byte, error) {

--- a/remotes/pull.go
+++ b/remotes/pull.go
@@ -134,13 +134,13 @@ func getBundleConfig(ctx context.Context, ref opts.NamedOption, repoOnly referen
 	if err != nil {
 		return nil, fmt.Errorf("failed to pull bundle %q: %s", ref, err)
 	}
-	var b *bundle.Bundle
-	if err := json.Unmarshal(configPayload, b); err != nil {
+	var b bundle.Bundle
+	if err := json.Unmarshal(configPayload, &b); err != nil {
 		return nil, fmt.Errorf("failed to pull bundle %q: %s", ref, err)
 	}
 	logPayload(logger, b)
 
-	return b, nil
+	return &b, nil
 }
 
 func pullPayload(ctx context.Context, resolver remotes.Resolver, reference string, descriptor ocischemav1.Descriptor) ([]byte, error) {
@@ -154,5 +154,7 @@ func pullPayload(ctx context.Context, resolver remotes.Resolver, reference strin
 		return nil, err
 	}
 	defer reader.Close()
-	return ioutil.ReadAll(reader)
+
+	result, err := ioutil.ReadAll(reader)
+	return result, err
 }

--- a/remotes/pull_test.go
+++ b/remotes/pull_test.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/docker/cnab-to-oci/converter"
 	"github.com/docker/cnab-to-oci/tests"
 	"github.com/docker/distribution/reference"
 	ocischemav1 "github.com/opencontainers/image-spec/specs-go/v1"
@@ -30,8 +29,8 @@ func TestPull(t *testing.T) {
    "layers": null
 }`)
 
-	config := converter.CreateBundleConfig(tests.MakeTestBundle())
-	bufBundleConfig, err := json.Marshal(config)
+	b := tests.MakeTestBundle()
+	bufBundle, err := json.Marshal(b)
 	assert.NilError(t, err)
 
 	fetcher := &mockFetcher{indexBuffers: []*bytes.Buffer{
@@ -40,7 +39,7 @@ func TestPull(t *testing.T) {
 		// Bundle config manifest
 		bytes.NewBuffer(bundleConfigManifestDescriptor),
 		// Bundle config
-		bytes.NewBuffer(bufBundleConfig),
+		bytes.NewBuffer(bufBundle),
 	}}
 	resolver := &mockResolver{
 		fetcher: fetcher,
@@ -60,7 +59,7 @@ func TestPull(t *testing.T) {
 	assert.NilError(t, err)
 
 	// Pull the CNAB and get the bundle
-	b, err := Pull(context.Background(), ref, resolver)
+	b, _, err = Pull(context.Background(), ref, resolver)
 	assert.NilError(t, err)
 	expectedBundle := tests.MakeTestBundle()
 	assert.DeepEqual(t, expectedBundle, b)
@@ -76,7 +75,7 @@ func ExamplePull() {
 	}
 
 	// Pull the CNAB and get the bundle
-	resultBundle, err := Pull(context.Background(), ref, resolver)
+	resultBundle, _, err := Pull(context.Background(), ref, resolver)
 	if err != nil {
 		panic(err)
 	}

--- a/remotes/push.go
+++ b/remotes/push.go
@@ -161,7 +161,6 @@ func prepareIndexNonOCI(b *bundle.Bundle, relocationMap bundle.ImageRelocationMa
 
 func pushPayload(ctx context.Context, resolver remotes.Resolver, reference string, descriptor ocischemav1.Descriptor, payload []byte) error {
 	ctx = withMutedContext(ctx)
-	fmt.Println("PUSHING PAYLOAD", descriptor.Size, descriptor.Digest, string(payload))
 	pusher, err := resolver.Pusher(ctx, reference)
 	if err != nil {
 		return err

--- a/remotes/push.go
+++ b/remotes/push.go
@@ -161,6 +161,7 @@ func prepareIndexNonOCI(b *bundle.Bundle, relocationMap bundle.ImageRelocationMa
 
 func pushPayload(ctx context.Context, resolver remotes.Resolver, reference string, descriptor ocischemav1.Descriptor, payload []byte) error {
 	ctx = withMutedContext(ctx)
+	fmt.Println("PUSHING PAYLOAD", descriptor.Size, descriptor.Digest, string(payload))
 	pusher, err := resolver.Pusher(ctx, reference)
 	if err != nil {
 		return err

--- a/remotes/push_test.go
+++ b/remotes/push_test.go
@@ -118,7 +118,7 @@ func TestPush(t *testing.T) {
 	assert.NilError(t, err)
 
 	// push the bundle
-	_, err = Push(context.Background(), b, ref, resolver, true)
+	_, err = Push(context.Background(), b, bundle.ImageRelocationMap{}, ref, resolver, true)
 	assert.NilError(t, err)
 	assert.Equal(t, len(resolver.pushedReferences), 3)
 	assert.Equal(t, len(pusher.pushedDescriptors), 3)
@@ -152,7 +152,7 @@ func ExamplePush() {
 	}
 
 	// Push the bundle here
-	descriptor, err := Push(context.Background(), b, ref, resolver, true)
+	descriptor, err := Push(context.Background(), b, bundle.ImageRelocationMap{}, ref, resolver, true)
 	if err != nil {
 		panic(err)
 	}

--- a/remotes/push_test.go
+++ b/remotes/push_test.go
@@ -2,7 +2,6 @@ package remotes
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strings"
 	"testing"
@@ -11,6 +10,7 @@ import (
 	"github.com/docker/cnab-to-oci/converter"
 	"github.com/docker/cnab-to-oci/tests"
 	"github.com/docker/distribution/reference"
+	"github.com/docker/go/canonical/json"
 	ocischemav1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"gotest.tools/assert"
 )
@@ -21,7 +21,7 @@ const (
   "manifests": [
     {
       "mediaType":"application/vnd.oci.image.manifest.v1+json",
-      "digest":"sha256:c2d924f51be1192113cf24beb537bda557270deef9c104204e89afcee685b160",
+      "digest":"sha256:e3eb67b9ca812e0d594f7dbf6e9071b4dc9d06ca338a3e6f851f22f06cf16860",
       "size":189,
       "annotations":{
         "io.cnab.manifest.type":"config"
@@ -70,7 +70,7 @@ func TestPush(t *testing.T) {
 	pusher := &mockPusher{}
 	resolver := &mockResolver{pusher: pusher}
 	b := tests.MakeTestBundle()
-	expectedBundleConfig, err := json.Marshal(b)
+	expectedBundleConfig, err := json.MarshalCanonical(b)
 	assert.NilError(t, err)
 	ref, err := reference.ParseNamed("my.registry/namespace/my-app:my-tag")
 	assert.NilError(t, err)
@@ -125,7 +125,7 @@ func ExamplePush() {
 	// Output:
 	// {
 	//   "mediaType": "application/vnd.oci.image.index.v1+json",
-	//   "digest": "sha256:8e566d3ddbd45aea5c080b8566dcf341f16179ce84eaaf77066c94541e9fbd49",
+	//   "digest": "sha256:4b6f2d8802ec66b8738ba6d8a5e446433476d9f7d174b3d26dcf296ed05cb8cf",
 	//   "size": 1363
 	// }
 }

--- a/tests/helpers.go
+++ b/tests/helpers.go
@@ -29,28 +29,31 @@ func MakeTestBundle() *bundle.Bundle {
 		Images: map[string]bundle.Image{
 			"image-1": {
 				BaseImage: bundle.BaseImage{
-					Image:     "my.registry/namespace/my-app@sha256:d59a1aa7866258751a261bae525a1842c7ff0662d4f34a355d5f36826abc0341",
+					Image:     "my.registry/namespace/image-1",
 					ImageType: "oci",
 					MediaType: "application/vnd.oci.image.manifest.v1+json",
 					Size:      507,
+					Digest:    "sha256:d59a1aa7866258751a261bae525a1842c7ff0662d4f34a355d5f36826abc0341",
 				},
 			},
 			"another-image": {
 				BaseImage: bundle.BaseImage{
-					Image:     "my.registry/namespace/my-app@sha256:d59a1aa7866258751a261bae525a1842c7ff0662d4f34a355d5f36826abc0341",
+					Image:     "my.registry/namespace/another-image",
 					ImageType: "oci",
 					MediaType: "application/vnd.oci.image.manifest.v1+json",
 					Size:      507,
+					Digest:    "sha256:d59a1aa7866258751a261bae525a1842c7ff0662d4f34a355d5f36826abc0342",
 				},
 			},
 		},
 		InvocationImages: []bundle.InvocationImage{
 			{
 				BaseImage: bundle.BaseImage{
-					Image:     "my.registry/namespace/my-app@sha256:d59a1aa7866258751a261bae525a1842c7ff0662d4f34a355d5f36826abc0341",
+					Image:     "my.registry/namespace/my-app-invoc",
 					ImageType: "docker",
 					MediaType: "application/vnd.docker.distribution.manifest.v2+json",
 					Size:      506,
+					Digest:    "sha256:d59a1aa7866258751a261bae525a1842c7ff0662d4f34a355d5f36826abc0343",
 				},
 			},
 		},
@@ -113,7 +116,7 @@ func MakeTestOCIIndex() *ocischemav1.Index {
 				},
 			},
 			{
-				Digest:    "sha256:d59a1aa7866258751a261bae525a1842c7ff0662d4f34a355d5f36826abc0341",
+				Digest:    "sha256:d59a1aa7866258751a261bae525a1842c7ff0662d4f34a355d5f36826abc0343",
 				MediaType: "application/vnd.docker.distribution.manifest.v2+json",
 				Size:      506,
 				Annotations: map[string]string{
@@ -121,7 +124,7 @@ func MakeTestOCIIndex() *ocischemav1.Index {
 				},
 			},
 			{
-				Digest:    "sha256:d59a1aa7866258751a261bae525a1842c7ff0662d4f34a355d5f36826abc0341",
+				Digest:    "sha256:d59a1aa7866258751a261bae525a1842c7ff0662d4f34a355d5f36826abc0342",
 				MediaType: "application/vnd.oci.image.manifest.v1+json",
 				Size:      507,
 				Annotations: map[string]string{
@@ -139,5 +142,13 @@ func MakeTestOCIIndex() *ocischemav1.Index {
 				},
 			},
 		},
+	}
+}
+
+func MakeRelocationMap() bundle.ImageRelocationMap {
+	return bundle.ImageRelocationMap{
+		"my.registry/namespace/image-1":       "my.registry/namespace/my-app@sha256:d59a1aa7866258751a261bae525a1842c7ff0662d4f34a355d5f36826abc0341",
+		"my.registry/namespace/another-image": "my.registry/namespace/my-app@sha256:d59a1aa7866258751a261bae525a1842c7ff0662d4f34a355d5f36826abc0342",
+		"my.registry/namespace/my-app-invoc":  "my.registry/namespace/my-app@sha256:d59a1aa7866258751a261bae525a1842c7ff0662d4f34a355d5f36826abc0343",
 	}
 }


### PR DESCRIPTION
closes #58

Still a draft because we need to add some more tests (including end-to-end tests) and do an overall cleanup (still plenty of `TODO`s left)

Changes in this PR:

- generate relocation map on both push and pull (regarding [@glyn's comment](https://github.com/deislabs/duffle/issues/690#issuecomment-520739646) about generating the map on `push`, it can be safely dropped - not entirely sure if it's better not to return it at all - WDYT?)
- store the entire `bundle.json` file in canonical form
- pull `bundle.json` in canonical form
- add a `fixup` flag for automatically updating the bundle when media type, content digest, and size are missing from an image.

Thanks to @silvin-lubecki for pairing on this!