### PR TITLE
Simple code cleanup

### DIFF
--- a/remotes/fixup_test.go
+++ b/remotes/fixup_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/platforms"
-	"github.com/containerd/containerd/remotes"
 	"github.com/deislabs/cnab-go/bundle"
 	"github.com/docker/cnab-to-oci/relocation"
 	"github.com/docker/distribution/reference"
@@ -391,11 +390,6 @@ func newTestManifest(plats ...string) *testManifest {
 		})
 	}
 	return m
-}
-
-type fetchSetup struct {
-	descriptor ocischemav1.Descriptor
-	fetcher    remotes.Fetcher
 }
 
 type bytesFetcher []byte

--- a/remotes/promises.go
+++ b/remotes/promises.go
@@ -102,14 +102,12 @@ func (p promise) then(next func(ctx context.Context) error) promise {
 	}
 	go func() {
 		defer close(completionSource.done)
-		select {
-		case <-p.Done():
-			if err := p.Err(); err != nil {
-				completionSource.err = err
-				return
-			}
-			completionSource.err = p.scheduler.schedule(next).wait()
+		<-p.Done()
+		if err := p.Err(); err != nil {
+			completionSource.err = err
+			return
 		}
+		completionSource.err = p.scheduler.schedule(next).wait()
 	}()
 	return newPromise(p.scheduler, completionSource)
 }


### PR DESCRIPTION
- remove unused struct
- simplify `then` handler, there is no need for a select
