### PR TITLE
Update docker/cli to handle `types.AuthConfig`

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -85,16 +85,17 @@
   version = "v0.7.1-beta1"
 
 [[projects]]
-  digest = "1:982e3778851f5bb802c164c0baffa67eb7447b189211a08dd18acaa03b4d30c0"
+  digest = "1:2170ed70165a085c25d4af4a090338ec75434088fdaf878e2bb99b779a93bdca"
   name = "github.com/docker/cli"
   packages = [
     "cli/config",
     "cli/config/configfile",
     "cli/config/credentials",
+    "cli/config/types",
     "opts",
   ]
   pruneopts = "UT"
-  revision = "f95ca8e1ba6c22c9abcdbf65e8dcc39c53958bba"
+  revision = "23446275646041f9b598d64c51be24d5d0e49376"
 
 [[projects]]
   digest = "1:f5b3251e0108c8186e46628fad8594b5b6a2ec8790068ab7c922199b6b018d2e"
@@ -473,6 +474,7 @@
     "github.com/deislabs/cnab-go/bundle/definition",
     "github.com/docker/cli/cli/config",
     "github.com/docker/cli/cli/config/configfile",
+    "github.com/docker/cli/cli/config/types",
     "github.com/docker/cli/opts",
     "github.com/docker/distribution",
     "github.com/docker/distribution/manifest/schema2",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -44,6 +44,10 @@
   name = "github.com/docker/docker-credential-helpers"
   version = "v0.6.3"
 
+[[override]]
+  name = "github.com/docker/cli"
+  revision = "23446275646041f9b598d64c51be24d5d0e49376"
+
 [prune]
   go-tests = true
   unused-packages = true

--- a/remotes/push.go
+++ b/remotes/push.go
@@ -9,6 +9,7 @@ import (
 	"os"
 
 	"github.com/docker/cli/cli/config"
+	configtypes "github.com/docker/cli/cli/config/types"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/jsonmessage"
@@ -268,7 +269,7 @@ func pushTaggedImage(ctx context.Context, imageClient client.ImageAPIClient, tar
 	return jsonmessage.DisplayJSONMessagesStream(reader, out, 0, false, nil)
 }
 
-func encodeAuthToBase64(authConfig types.AuthConfig) (string, error) {
+func encodeAuthToBase64(authConfig configtypes.AuthConfig) (string, error) {
 	buf, err := json.Marshal(authConfig)
 	if err != nil {
 		return "", err
@@ -276,7 +277,7 @@ func encodeAuthToBase64(authConfig types.AuthConfig) (string, error) {
 	return base64.URLEncoding.EncodeToString(buf), nil
 }
 
-func resolveAuthConfig(index *registrytypes.IndexInfo) types.AuthConfig {
+func resolveAuthConfig(index *registrytypes.IndexInfo) configtypes.AuthConfig {
 	cfg := config.LoadDefaultConfigFile(os.Stderr)
 
 	hostName := index.Name
@@ -286,12 +287,12 @@ func resolveAuthConfig(index *registrytypes.IndexInfo) types.AuthConfig {
 
 	configs, err := cfg.GetAllCredentials()
 	if err != nil {
-		return types.AuthConfig{}
+		return configtypes.AuthConfig{}
 	}
 
 	authConfig, ok := configs[hostName]
 	if !ok {
-		return types.AuthConfig{}
+		return configtypes.AuthConfig{}
 	}
 	return authConfig
 }

--- a/vendor/github.com/docker/cli/cli/config/config.go
+++ b/vendor/github.com/docker/cli/cli/config/config.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/docker/cli/cli/config/configfile"
 	"github.com/docker/cli/cli/config/credentials"
-	"github.com/docker/docker/api/types"
+	"github.com/docker/cli/cli/config/types"
 	"github.com/docker/docker/pkg/homedir"
 	"github.com/pkg/errors"
 )
@@ -44,6 +44,11 @@ func ContextStoreDir() string {
 // SetDir sets the directory the configuration file is stored in
 func SetDir(dir string) {
 	configDir = dir
+}
+
+// Path returns the path to a file relative to the config dir
+func Path(p ...string) string {
+	return filepath.Join(append([]string{Dir()}, p...)...)
 }
 
 // LegacyLoadFromReader is a convenience function that creates a ConfigFile object from

--- a/vendor/github.com/docker/cli/cli/config/configfile/file.go
+++ b/vendor/github.com/docker/cli/cli/config/configfile/file.go
@@ -11,8 +11,7 @@ import (
 	"strings"
 
 	"github.com/docker/cli/cli/config/credentials"
-	"github.com/docker/cli/opts"
-	"github.com/docker/docker/api/types"
+	"github.com/docker/cli/cli/config/types"
 	"github.com/pkg/errors"
 )
 
@@ -49,6 +48,7 @@ type ConfigFile struct {
 	StackOrchestrator    string                      `json:"stackOrchestrator,omitempty"`
 	Kubernetes           *KubernetesConfig           `json:"kubernetes,omitempty"`
 	CurrentContext       string                      `json:"currentContext,omitempty"`
+	CLIPluginsExtraDirs  []string                    `json:"cliPluginsExtraDirs,omitempty"`
 }
 
 // ProxyConfig contains proxy configuration settings
@@ -195,7 +195,7 @@ func (configFile *ConfigFile) Save() error {
 
 // ParseProxyConfig computes proxy configuration by retrieving the config for the provided host and
 // then checking this against any environment variables provided to the container
-func (configFile *ConfigFile) ParseProxyConfig(host string, runOpts []string) map[string]*string {
+func (configFile *ConfigFile) ParseProxyConfig(host string, runOpts map[string]*string) map[string]*string {
 	var cfgKey string
 
 	if _, ok := configFile.Proxies[host]; !ok {
@@ -211,7 +211,10 @@ func (configFile *ConfigFile) ParseProxyConfig(host string, runOpts []string) ma
 		"NO_PROXY":    &config.NoProxy,
 		"FTP_PROXY":   &config.FTPProxy,
 	}
-	m := opts.ConvertKVStringsToMapWithNil(runOpts)
+	m := runOpts
+	if m == nil {
+		m = make(map[string]*string)
+	}
 	for k := range permitted {
 		if *permitted[k] == "" {
 			continue

--- a/vendor/github.com/docker/cli/cli/config/credentials/credentials.go
+++ b/vendor/github.com/docker/cli/cli/config/credentials/credentials.go
@@ -1,7 +1,7 @@
 package credentials
 
 import (
-	"github.com/docker/docker/api/types"
+	"github.com/docker/cli/cli/config/types"
 )
 
 // Store is the interface that any credentials store must implement.

--- a/vendor/github.com/docker/cli/cli/config/credentials/native_store.go
+++ b/vendor/github.com/docker/cli/cli/config/credentials/native_store.go
@@ -1,9 +1,9 @@
 package credentials
 
 import (
+	"github.com/docker/cli/cli/config/types"
 	"github.com/docker/docker-credential-helpers/client"
 	"github.com/docker/docker-credential-helpers/credentials"
-	"github.com/docker/docker/api/types"
 )
 
 const (

--- a/vendor/github.com/docker/cli/cli/config/types/authconfig.go
+++ b/vendor/github.com/docker/cli/cli/config/types/authconfig.go
@@ -1,0 +1,22 @@
+package types
+
+// AuthConfig contains authorization information for connecting to a Registry
+type AuthConfig struct {
+	Username string `json:"username,omitempty"`
+	Password string `json:"password,omitempty"`
+	Auth     string `json:"auth,omitempty"`
+
+	// Email is an optional value associated with the username.
+	// This field is deprecated and will be removed in a later
+	// version of docker.
+	Email string `json:"email,omitempty"`
+
+	ServerAddress string `json:"serveraddress,omitempty"`
+
+	// IdentityToken is used to authenticate the user and get
+	// an access token for the registry.
+	IdentityToken string `json:"identitytoken,omitempty"`
+
+	// RegistryToken is a bearer token to be sent to a registry
+	RegistryToken string `json:"registrytoken,omitempty"`
+}


### PR DESCRIPTION
Override `docker/cli` dependency to docker/cli@23446275646041f9b598d64c51be24d5d0e49376
This commit is a little more recent than the one provided by `deislabs/cnab-go` that is docker/cli@f95ca8e1ba6c22c9abcdbf65e8dcc39c53958bba

This target commit is the one that copies `types.AuthConfig` from docker api to docker cli.
By itself it's not an issue but it can be if `cnab-to-oci` is integrated in a context where a newer version of `docker/cli` is required.

See https://github.com/docker/cnab-to-oci/pull/76#discussion_r335174252 for example, and the same kind of issue exists in `docker/app` where both `cnab-to-oci` and a more recent `docker/cli` are used.