### PR TITLE
allow to push local docker images by digest

### DIFF
--- a/internal/image_client.go
+++ b/internal/image_client.go
@@ -1,0 +1,14 @@
+package internal
+
+import (
+	"context"
+	"io"
+
+	"github.com/docker/docker/api/types"
+)
+
+// ImageClient is a subset of Docker's ImageAPIClient interface with only what we are using for cnab-to-oci.
+type ImageClient interface {
+	ImagePush(ctx context.Context, ref string, options types.ImagePushOptions) (io.ReadCloser, error)
+	ImageTag(ctx context.Context, image, ref string) error
+}

--- a/remotes/fixup.go
+++ b/remotes/fixup.go
@@ -48,12 +48,12 @@ func FixupBundle(ctx context.Context, b *bundle.Bundle, ref reference.Named, res
 	}
 
 	relocationMap := relocation.ImageRelocationMap{}
-	if err := fixupImage(ctx, &b.InvocationImages[0].BaseImage, relocationMap, cfg, events, cfg.invocationImagePlatformFilter); err != nil {
+	if err := fixupImage(ctx, "InvocationImage", &b.InvocationImages[0].BaseImage, relocationMap, cfg, events, cfg.invocationImagePlatformFilter); err != nil {
 		return nil, err
 	}
 	// Fixup images
 	for name, original := range b.Images {
-		if err := fixupImage(ctx, &original.BaseImage, relocationMap, cfg, events, cfg.componentImagePlatformFilter); err != nil {
+		if err := fixupImage(ctx, name, &original.BaseImage, relocationMap, cfg, events, cfg.componentImagePlatformFilter); err != nil {
 			return nil, err
 		}
 		b.Images[name] = original
@@ -63,14 +63,22 @@ func FixupBundle(ctx context.Context, b *bundle.Bundle, ref reference.Named, res
 	return relocationMap, nil
 }
 
-func fixupImage(ctx context.Context, baseImage *bundle.BaseImage, relocationMap relocation.ImageRelocationMap, cfg fixupConfig, events chan<- FixupEvent, platformFilter platforms.Matcher) error {
+func fixupImage(
+	ctx context.Context,
+	name string,
+	baseImage *bundle.BaseImage,
+	relocationMap relocation.ImageRelocationMap,
+	cfg fixupConfig,
+	events chan<- FixupEvent,
+	platformFilter platforms.Matcher) error {
+
 	log.G(ctx).Debugf("Updating entry in relocation map for %q", baseImage.Image)
 	ctx = withMutedContext(ctx)
 	notifyEvent, progress := makeEventNotifier(events, baseImage.Image, cfg.targetRef)
 
 	notifyEvent(FixupEventTypeCopyImageStart, "", nil)
 	// Fixup Base image
-	fixupInfo, err := fixupBaseImage(ctx, baseImage, cfg)
+	fixupInfo, pushed, err := fixupBaseImage(ctx, name, baseImage, cfg)
 	if err != nil {
 		return notifyError(notifyEvent, err)
 	}
@@ -97,6 +105,11 @@ func fixupImage(ctx context.Context, baseImage *bundle.BaseImage, relocationMap 
 		if baseImage.MediaType != fixupInfo.resolvedDescriptor.MediaType {
 			return fmt.Errorf("image %q media type differs %q after fixup: %q", baseImage.Image, baseImage.MediaType, fixupInfo.resolvedDescriptor.MediaType)
 		}
+	}
+
+	if pushed {
+		notifyEvent(FixupEventTypeCopyImageEnd, "Image has been pushed for service "+name, nil)
+		return nil
 	}
 
 	if fixupInfo.sourceRef.Name() == fixupInfo.targetRepo.Name() {
@@ -181,38 +194,57 @@ func fixupPlatforms(ctx context.Context,
 	return nil
 }
 
-func fixupBaseImage(ctx context.Context, baseImage *bundle.BaseImage, cfg fixupConfig) (imageFixupInfo, error) {
+func fixupBaseImage(ctx context.Context, name string, baseImage *bundle.BaseImage, cfg fixupConfig) (imageFixupInfo, bool, error) {
 	// Check image references
 	if err := checkBaseImage(baseImage); err != nil {
-		return imageFixupInfo{}, fmt.Errorf("invalid image %q: %s", baseImage.Image, err)
+		return imageFixupInfo{}, false, fmt.Errorf("invalid image %q for service %q: %s", baseImage.Image, name, err)
 	}
 	targetRepoOnly, err := reference.ParseNormalizedNamed(cfg.targetRef.Name())
 	if err != nil {
-		return imageFixupInfo{}, err
+		return imageFixupInfo{}, false, err
 	}
-	sourceImageRef, err := reference.ParseNormalizedNamed(baseImage.Image)
-	if err != nil {
-		return imageFixupInfo{}, fmt.Errorf("%q is not a valid image reference for %q: %s", baseImage.Image, cfg.targetRef, err)
-	}
-	sourceImageRef = reference.TagNameOnly(sourceImageRef)
 
-	// Try to fetch the image descriptor
-	_, descriptor, err := cfg.resolver.Resolve(ctx, sourceImageRef.String())
-	if err != nil {
-		if cfg.pushImages {
-			descriptor, err = pushImageToTarget(ctx, baseImage, cfg)
-			if err != nil {
-				return imageFixupInfo{}, err
+	var (
+		descriptor     ocischemav1.Descriptor
+		pushed         bool
+		sourceImageRef reference.Named
+	)
+
+	if baseImage.Image == "" && cfg.pushImages {
+		// no image is defined for the service, try to push by digest from local docker image store
+		descriptor, err = pushImageToTarget(ctx, baseImage.Digest, cfg)
+		if err != nil {
+			return imageFixupInfo{}, false, err
+		}
+		pushed = true
+	} else {
+		// try to resolve
+		sourceImageRef, err = reference.ParseNormalizedNamed(baseImage.Image)
+		if err != nil {
+			return imageFixupInfo{}, false, fmt.Errorf("%q is not a valid image reference for %q: %s", baseImage.Image, cfg.targetRef, err)
+		}
+		sourceImageRef = reference.TagNameOnly(sourceImageRef)
+
+		// Try to fetch the image descriptor
+		_, descriptor, err = cfg.resolver.Resolve(ctx, sourceImageRef.String())
+		if err != nil {
+			if cfg.pushImages {
+				// try to push from local docker image store
+				descriptor, err = pushImageToTarget(ctx, baseImage.Image, cfg)
+				if err != nil {
+					return imageFixupInfo{}, false, err
+				}
+				pushed = true
+			} else {
+				return imageFixupInfo{}, false, fmt.Errorf("failed to resolve %q, push the image for service %q to the registry before pushing the bundle: %s", sourceImageRef, name, err)
 			}
-		} else {
-			return imageFixupInfo{}, fmt.Errorf("failed to resolve %q, push the image to the registry before pushing the bundle: %s", sourceImageRef, err)
 		}
 	}
 	return imageFixupInfo{
-		resolvedDescriptor: descriptor,
-		sourceRef:          sourceImageRef,
 		targetRepo:         targetRepoOnly,
-	}, nil
+		sourceRef:          sourceImageRef,
+		resolvedDescriptor: descriptor,
+	}, pushed, nil
 }
 
 // pushImageToTarget pushes the image from the local docker daemon store to the target defined in the configuration.
@@ -226,15 +258,15 @@ func fixupBaseImage(ctx context.Context, baseImage *bundle.BaseImage, cfg fixupC
 //  - tag the image to push with targeted reference
 //  - push the image using a docker `ImageAPIClient`
 //  - resolve the pushed image to grab its digest
-func pushImageToTarget(ctx context.Context, baseImage *bundle.BaseImage, cfg fixupConfig) (ocischemav1.Descriptor, error) {
+func pushImageToTarget(ctx context.Context, src string, cfg fixupConfig) (ocischemav1.Descriptor, error) {
 	taggedRef := reference.TagNameOnly(cfg.targetRef)
 
-	if err := cfg.imageClient.ImageTag(ctx, baseImage.Image, cfg.targetRef.String()); err != nil {
-		return ocischemav1.Descriptor{}, fmt.Errorf("failed to push image %q, make sure the image exists locally: %s", baseImage.Image, err)
+	if err := cfg.imageClient.ImageTag(ctx, src, cfg.targetRef.String()); err != nil {
+		return ocischemav1.Descriptor{}, fmt.Errorf("failed to push image %q, make sure the image exists locally: %s", src, err)
 	}
 
 	if err := pushTaggedImage(ctx, cfg.imageClient, cfg.targetRef, cfg.pushOut); err != nil {
-		return ocischemav1.Descriptor{}, fmt.Errorf("failed to push image %q: %s", baseImage.Image, err)
+		return ocischemav1.Descriptor{}, fmt.Errorf("failed to push image %q: %s", src, err)
 	}
 
 	_, descriptor, err := cfg.resolver.Resolve(ctx, taggedRef.String())

--- a/remotes/fixupoptions.go
+++ b/remotes/fixupoptions.go
@@ -5,11 +5,12 @@ import (
 	"io"
 	"io/ioutil"
 
+	"github.com/docker/cnab-to-oci/internal"
+
 	"github.com/containerd/containerd/platforms"
 	"github.com/containerd/containerd/remotes"
 	"github.com/deislabs/cnab-go/bundle"
 	"github.com/docker/distribution/reference"
-	"github.com/docker/docker/client"
 	ocischemav1 "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
@@ -32,7 +33,7 @@ type fixupConfig struct {
 	componentImagePlatformFilter  platforms.Matcher
 	autoBundleUpdate              bool
 	pushImages                    bool
-	imageClient                   client.ImageAPIClient
+	imageClient                   internal.ImageClient
 	pushOut                       io.Writer
 }
 
@@ -129,7 +130,7 @@ func WithAutoBundleUpdate() FixupOption {
 // target tag.
 // But local only images (for example after a local build of components of the bundle) must be pushed.
 // This option will allow to push images that are only available in the docker daemon image store to the defined target.
-func WithPushImages(imageClient client.ImageAPIClient, out io.Writer) FixupOption {
+func WithPushImages(imageClient internal.ImageClient, out io.Writer) FixupOption {
 	return func(cfg *fixupConfig) error {
 		cfg.pushImages = true
 		if imageClient == nil {

--- a/remotes/push.go
+++ b/remotes/push.go
@@ -8,10 +8,11 @@ import (
 	"io"
 	"os"
 
+	"github.com/docker/cnab-to-oci/internal"
+
 	"github.com/docker/cli/cli/config"
 	configtypes "github.com/docker/cli/cli/config/types"
 	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/jsonmessage"
 	"github.com/docker/docker/registry"
 
@@ -247,7 +248,7 @@ func pushBundleConfigDescriptor(ctx context.Context, name string, resolver remot
 	return descriptor, nil
 }
 
-func pushTaggedImage(ctx context.Context, imageClient client.ImageAPIClient, targetRef reference.Named, out io.Writer) error {
+func pushTaggedImage(ctx context.Context, imageClient internal.ImageClient, targetRef reference.Named, out io.Writer) error {
 	repoInfo, err := registry.ParseRepositoryInfo(targetRef)
 	if err != nil {
 		return err


### PR DESCRIPTION
In the case `contentDigest` is defined (for example after a build
by docker app) try to push local docker image from the digest.
In that case, the `image` of the service is not defined in the
bundle.json.

If `contentDigest` is empty, do the same thing as before, so try to resolve
and if it's not resolvable try to push.

The service name is now displayed in error messages to better understand
what's going on on failures.

Signed-off-by: Yves Brissaud <yves.brissaud@docker.com>