### PR TITLE
fallback to relocation map when image is not found

### DIFF
--- a/remotes/mocks_test.go
+++ b/remotes/mocks_test.go
@@ -108,6 +108,7 @@ func (rc mockReadCloser) Close() error {
 }
 
 type mockImageClient struct {
+	pushedImages int
 }
 
 func newMockImageClient() *mockImageClient {
@@ -115,6 +116,7 @@ func newMockImageClient() *mockImageClient {
 }
 
 func (c *mockImageClient) ImagePush(ctx context.Context, ref string, options types.ImagePushOptions) (io.ReadCloser, error) {
+	c.pushedImages++
 	return mockReadCloser{}, nil
 }
 func (c *mockImageClient) ImageTag(ctx context.Context, image, ref string) error {


### PR DESCRIPTION
When we are doing the `fixup` of a bundle, apply relocation map when necessary.

Previous behaviour:
- resolve image
  - if found, copy or mount
  - if not found
    - if image present in local docker image store
      - push

The goal of this commit is to add one more condition, to copy/mount images that has been previously pushed from the local docker image store and so that can be resolved using the relocation map.

So the behaviour looks like:
- look at relocation map for entry corresponding to the image
  - if found
    - if resolved, copy and return from here
- if not found from relocation map or not resolvable
  - resolve image from bundle definition
    - if resolved, copy and return from here
- if not resolved but present in the local docker image store
  - push

The affected workflow is the following:

1. create a bundle referencing local images. Like after a `docker app build`
   - the bundle contains images with, by example, `Image: web`
2. push it to a registry
3. pull it (by example on an other machine)
   - the bundle contains `Image: web` associated to an entry in the
   relocation map: `web: registry/user/repo:tag@sha256...`
4. push it (to an other registry or not)
   - the image `web` is not resolved in the registry (but the corresponding
   image has already been pushed)
   - the image cannot be pushed from the local docker image store (the image
   doesn't exist there)
   - the entry from the relocation maps is resolvable and can be copy or mount

Implementation details:

The way `fixupBaseImage` works has been changed. Instead of having a bunch of `if/else` a list of fixups functions is provided. Those functions are run one after the other. If the function returns an error, then we "try" with the next one. If the function returns a flag indicated it's OK, it means the image has been resolved, directly or using relocation map or after a push.
Conditions (like checking the relocation map or the `pushImages` flag) are checked inside functions.

The order is the following:

1. try to push by digest if image value is not set
3. try to resolve using the relocation map
2. try to resolve from bundle
4. try to push from local image store
