### PR TITLE
convert to hostname if needed when trying to authenticate

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -474,6 +474,7 @@
     "github.com/deislabs/cnab-go/bundle/definition",
     "github.com/docker/cli/cli/config",
     "github.com/docker/cli/cli/config/configfile",
+    "github.com/docker/cli/cli/config/credentials",
     "github.com/docker/cli/cli/config/types",
     "github.com/docker/cli/opts",
     "github.com/docker/distribution",

--- a/remotes/push.go
+++ b/remotes/push.go
@@ -8,6 +8,8 @@ import (
 	"io"
 	"os"
 
+	"github.com/docker/cli/cli/config/credentials"
+
 	"github.com/docker/cnab-to-oci/internal"
 
 	"github.com/docker/cli/cli/config"
@@ -291,8 +293,16 @@ func resolveAuthConfig(index *registrytypes.IndexInfo) configtypes.AuthConfig {
 		return configtypes.AuthConfig{}
 	}
 
+	// See https://github.com/docker/cli/blob/23446275646041f9b598d64c51be24d5d0e49376/cli/config/credentials/file_store.go#L32-L47
+	// We are looking for the hostname in the configuration, and if not we are trying with a pure hostname (so without
+	// http/https).
 	authConfig, ok := configs[hostName]
 	if !ok {
+		for reg, config := range configs {
+			if hostName == credentials.ConvertToHostname(reg) {
+				return config
+			}
+		}
 		return configtypes.AuthConfig{}
 	}
 	return authConfig


### PR DESCRIPTION
Used for the push using Docker's cli.
See https://github.com/docker/cli/blob/23446275646041f9b598d64c51be24d5d0e49376/cli/config/credentials/file_store.go#L32-L47 (current used revision) to have more information about this fix.

By example if you are logged on multiple registries, you can have something like that in your `config.json`.

```json
{
        "auths": {
                "https://index.docker.io/v1/": {},
                "quay.io": {},
        }
}
```

This fix allows to handle auth configurations with and without `http[s]://` prefix.